### PR TITLE
Adds the Building Permits data set to the manifest, and fixes a couple loading issues

### DIFF
--- a/scripts/preprocessing/load_data.py
+++ b/scripts/preprocessing/load_data.py
@@ -16,6 +16,7 @@ import pandas as pd
 from sqlalchemy import create_engine
 import csv
 import dateutil
+import string
 
 #Configure logging. See /logs/example-logging.py for examples of how to use this.
 logging_filename = "../logs/ingestion.log"
@@ -80,10 +81,12 @@ def csv_to_sql(index_path):
             parser = lambda x: pd.to_datetime(x, errors='coerce', infer_datetime_format=True)
 
             #Read the file into Pandas, and then reformat the column names to follow SQL conventions/best practice.
-            csv_df = pd.read_csv(full_path, encoding="latin_1", parse_dates=to_parse, date_parser=parser)
+            csv_df = pd.read_csv(full_path, encoding="latin_1", parse_dates=to_parse, date_parser=parser, low_memory=False)
             csv_df.columns = map(str.lower, csv_df.columns)
             csv_df.columns = [c.replace(' ', '_') for c in csv_df.columns]
             csv_df.columns = [c.replace('.', '_') for c in csv_df.columns]
+            #remove nonprinting/non-ascii characters:
+            csv_df.columns = [''.join(filter(lambda x: x in string.printable, c)) for c in csv_df.columns]
             logging.info("  in memory...")
 
             #Add a column so that we can put all the snapshots in the same table

--- a/scripts/preprocessing/load_manifest.csv
+++ b/scripts/preprocessing/load_manifest.csv
@@ -32,4 +32,5 @@ skip,ACS_13_5YR,acs_rent_upper,7/1/2011,../../../housing-risk/data/acs/median_re
 loaded,ACS_14_5YR,acs_rent_lower,7/1/2012,../../../housing-risk/data/acs/median_rent_by_tract/2014_5year/,ACS_14_5YR_B25057_with_ann.csv,lower_quartile
 loaded,ACS_14_5YR,acs_rent_median,7/1/2012,../../../housing-risk/data/acs/median_rent_by_tract/2014_5year/,ACS_14_5YR_B25058_with_ann.csv,median
 loaded,ACS_14_5YR,acs_rent_upper,7/1/2012,../../../housing-risk/data/acs/median_rent_by_tract/2014_5year/,ACS_14_5YR_B25059_with_ann.csv,upper_quartile
-,census_mapping,census_mapping,1/5/2017,../small_data/CensusTractMapping/,DC_census_tract_crosswalk.csv,manually created based on .txt file in same folder
+loaded,census_mapping,census_mapping,1/5/2017,../small_data/CensusTractMapping/,DC_census_tract_crosswalk.csv,manually created based on .txt file in same folder
+,opendata_2016,building_permits,1/6/2016,../big_data/building_permits/,Building_Permits_2016.csv,Unclear what date this is from - meta data says jan 2016 but there are more permits than that


### PR DESCRIPTION
Building permits data **has** been loaded into the AWS database. No need to re-run

Solves:
- Low Memory error that showed up in the read_csv method
- Non-printing characters at the start of the file (i.e. in the header name of the first column) now removed