### PR TITLE
Re: Issue 52 - add metrics menu

### DIFF
--- a/docs/css/prototype-1a.css
+++ b/docs/css/prototype-1a.css
@@ -1,3 +1,23 @@
+#metric_menu{
+  list-style: none;
+  width: 20%;
+}
+
+#metric_menu h1{
+  font-size: 1em;
+  font-weight: bold;
+  text-transform: uppercase;
+  padding: 3px;
+  border: 1px solid black;
+  margin-bottom: 0px;
+  color: rgb(64, 180, 180);
+}
+.metric_option{
+  border: 1px solid black;
+  font-size: 1em;
+  cursor: pointer;
+  padding: 3px;
+}
 
 .d3-tip {
       line-height: 1;
@@ -8,20 +28,7 @@
       font-size: 12px;
 
     }
- 
-    /* Creates a small triangle extender for the tooltip */
-    /*   .d3-tip:before {
-      box-sizing: border-box;
-      display: inline;
-      font-size: 10px;
-      width: 100%; 
-      line-height: 1;
-      color: rgba(0, 0, 0, 0.8);
-      content: "\25BC";
-      position: relative;
-      text-align: center;
-    }*/
- 
+  
     /* Style northward tooltips specifically */
     .d3-tip.n:after {
       margin: -2px 0 0 0;

--- a/docs/d3-mockup/index.md
+++ b/docs/d3-mockup/index.md
@@ -13,6 +13,9 @@ customCSS: prototype-1a
 **Initial sort is by zip code (top to bottom then right)**
 
 a.
+<ul id = "metric_menu">
+  <h1>Metrics</h1>
+</ul>
 <div id="chart-0" class="d3-chart"></div>
 <!-- next prototype goes below -->
 <!--b.


### PR DESCRIPTION
I've done a bit of work on making the moving block chart prototype page resemble the original [mock-up](https://app.moqups.com/neal@nhumphrey.com/zeZOXaXpNx/view/page/abd7c6e09?ui=0). So far, I've focused on creating a 'METRICS' menu that changes the field of the block chart. In producing the menu, I've made some design decisions that probably have better alternatives. I've summarized them below. Let me know what you think and feel free to revamp.

1. I'm okay with the 'without extend prototype' branch, but have put off incorporating it in case it's still something we're talking about.

2. I've added the Metrics menu to 'prototype-1a.js'. If this file was intended only for testing out the d3 functionality (rather than implementing the mock-up in general), I'd be happy to move the increasingly complex UI into a new file.

3. I've produced the menu using a \<ul\> element to avoid the cross-browser issues that apparently exist with styling \<select\> elements. That said, we can still go with a \<select\> approach.

4. The menu refreshes the 'field' of each chart by deleting the chart's <svg> element and children, then adding the chart again by calling the constructor. I found it simpler this way, but we could also look at assigning new fields to an existing d3 chart object.

5. Each Metric menu option stores an array of Chart arguments. The Metric instance then uses the array to create new Charts. This is because the MovingBlockChart constructor adds the chart to the page automatically when called. It's not possible to assign a Chart to a Metric menu option without adding the chart to the page. An alternative would be to add a ‘create’ or ‘render’ method to each Chart, so adding the chart to the page would not be part of the initialSetup/setup methods. Instead, the Chart itself would be assigned to the menu option.

6. I’m adding a chart constructor to the arguments of the Metric constructor. This is to allow for assigning different kinds of charts to each Metric menu option. An alternative would be to assign not a constructor but an entire Chart object (similar to point 5).

7. I need a good way to create an object using both a constructor and 'apply()'. This way the Metric constructor can take the constructor for a Chart (i.e. MovingBlockChart or some other kind) as an argument and call that constructor with the array of Chart arguments.