### PR TITLE
Provide baseline javascript for all Charts;Recreates moving blocks in…

### DIFF
--- a/javascript/tool/building.html
+++ b/javascript/tool/building.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Building View</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.4.1/d3.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="css/tool.css">
 </head>
 <body>
   <header class="building-header">
@@ -19,9 +21,11 @@
     </section>
   </section>
 
-  <script src="housing-insights.js"></script>
-  <script src="building-chart.js"></script>
-  <script src="building-map.js"></script>
-  <script src="building-header.js"></script>
+  <script src="js/d3-tip.js"></script>
+  <script src="js/PubSub.js"></script>
+  <script src="js/housing-insights.js"></script>
+  <script src="js/building-chart.js"></script>
+  <script src="js/building-map.js"></script>
+  <script src="js/building-header.js"></script>
 </body>
 </html>

--- a/javascript/tool/css/moving-blocks.css
+++ b/javascript/tool/css/moving-blocks.css
@@ -1,0 +1,46 @@
+.d3-tip {
+      line-height: 1;
+      padding: 6px;
+      background: rgba(0, 0, 0, 0.8);
+      color: #fff;
+      border-radius: 4px;
+      font-size: 12px;
+
+    }
+  
+    /* Style northward tooltips specifically */
+    .d3-tip.n:after {
+      margin: -2px 0 0 0;
+      top: 100%;
+      left: 0;
+    }
+
+
+.d3-chart rect {
+  fill: #325d88; 
+}
+
+.d3-chart {
+  max-width: 400px;
+}
+
+.d3-chart rect.under-threshold {
+  fill: gray;
+  fill-opacity:0.2; 
+}
+
+.d3-chart rect:hover {
+    fill: #bada33;
+    fill-opacity: 1;
+}
+
+rect.null-value {
+  stroke: #ccc;
+  stroke-width: 1px;
+  shape-rendering: crispEdges;
+}
+
+.d3-chart button {
+  margin-right: 10px;
+}
+

--- a/javascript/tool/js/PubSub.js
+++ b/javascript/tool/js/PubSub.js
@@ -1,0 +1,215 @@
+/*
+Copyright (c) 2010,2011,2012,2013 Morgan Roderick http://roderick.dk
+License: MIT - http://mrgnrdrck.mit-license.org
+
+https://github.com/mroderick/PubSubJS
+*/
+/*jslint white:true, plusplus:true, stupid:true*/
+/*global
+    setTimeout,
+    module,
+    exports,
+    define,
+    require,
+    window
+*/
+(function(root, factory){
+    'use strict';
+
+    // CommonJS
+    if (typeof exports === 'object' && module){
+        module.exports = factory();
+
+    // AMD
+    } else if (typeof define === 'function' && define.amd){
+        define(factory);
+    // Browser
+    } else {
+        root.PubSub = factory();
+    }
+}( ( typeof window === 'object' && window ) || this, function(){
+
+    'use strict';
+
+    var PubSub = {},
+        messages = {},
+        lastUid = -1;
+
+    function hasKeys(obj){
+        var key;
+
+        for (key in obj){
+            if ( obj.hasOwnProperty(key) ){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     *  Returns a function that throws the passed exception, for use as argument for setTimeout
+     *  @param { Object } ex An Error object
+     */
+    function throwException( ex ){
+        return function reThrowException(){
+            throw ex;
+        };
+    }
+
+    function callSubscriberWithDelayedExceptions( subscriber, message, data ){
+        try {
+            subscriber( message, data );
+        } catch( ex ){
+            setTimeout( throwException( ex ), 0);
+        }
+    }
+
+    function callSubscriberWithImmediateExceptions( subscriber, message, data ){
+        subscriber( message, data );
+    }
+
+    function deliverMessage( originalMessage, matchedMessage, data, immediateExceptions ){
+        var subscribers = messages[matchedMessage],
+            callSubscriber = immediateExceptions ? callSubscriberWithImmediateExceptions : callSubscriberWithDelayedExceptions,
+            s;
+
+        if ( !messages.hasOwnProperty( matchedMessage ) ) {
+            return;
+        }
+
+        for (s in subscribers){
+            if ( subscribers.hasOwnProperty(s)){
+                callSubscriber( subscribers[s], originalMessage, data );
+            }
+        }
+    }
+
+    function createDeliveryFunction( message, data, immediateExceptions ){
+        return function deliverNamespaced(){
+            var topic = String( message ),
+                position = topic.lastIndexOf( '.' );
+
+            // deliver the message as it is now
+            deliverMessage(message, message, data, immediateExceptions);
+
+            // trim the hierarchy and deliver message to each level
+            while( position !== -1 ){
+                topic = topic.substr( 0, position );
+                position = topic.lastIndexOf('.');
+                deliverMessage( message, topic, data );
+            }
+        };
+    }
+
+    function messageHasSubscribers( message ){
+        var topic = String( message ),
+            found = Boolean(messages.hasOwnProperty( topic ) && hasKeys(messages[topic])),
+            position = topic.lastIndexOf( '.' );
+
+        while ( !found && position !== -1 ){
+            topic = topic.substr( 0, position );
+            position = topic.lastIndexOf( '.' );
+            found = Boolean(messages.hasOwnProperty( topic ) && hasKeys(messages[topic]));
+        }
+
+        return found;
+    }
+
+    function publish( message, data, sync, immediateExceptions ){
+        var deliver = createDeliveryFunction( message, data, immediateExceptions ),
+            hasSubscribers = messageHasSubscribers( message );
+
+        if ( !hasSubscribers ){
+            return false;
+        }
+
+        if ( sync === true ){
+            deliver();
+        } else {
+            setTimeout( deliver, 0 );
+        }
+        return true;
+    }
+
+    /**
+     *  PubSub.publish( message[, data] ) -> Boolean
+     *  - message (String): The message to publish
+     *  - data: The data to pass to subscribers
+     *  Publishes the the message, passing the data to it's subscribers
+    **/
+    PubSub.publish = function( message, data ){
+        return publish( message, data, false, PubSub.immediateExceptions );
+    };
+
+    /**
+     *  PubSub.publishSync( message[, data] ) -> Boolean
+     *  - message (String): The message to publish
+     *  - data: The data to pass to subscribers
+     *  Publishes the the message synchronously, passing the data to it's subscribers
+    **/
+    PubSub.publishSync = function( message, data ){
+        return publish( message, data, true, PubSub.immediateExceptions );
+    };
+
+    /**
+     *  PubSub.subscribe( message, func ) -> String
+     *  - message (String): The message to subscribe to
+     *  - func (Function): The function to call when a new message is published
+     *  Subscribes the passed function to the passed message. Every returned token is unique and should be stored if
+     *  you need to unsubscribe
+    **/
+    PubSub.subscribe = function( message, func ){
+        if ( typeof func !== 'function'){
+            return false;
+        }
+
+        // message is not registered yet
+        if ( !messages.hasOwnProperty( message ) ){
+            messages[message] = {};
+        }
+
+        // forcing token as String, to allow for future expansions without breaking usage
+        // and allow for easy use as key names for the 'messages' object
+        var token = 'uid_' + String(++lastUid);
+        messages[message][token] = func;
+
+        // return token for unsubscribing
+        return token;
+    };
+
+    /**
+     *  PubSub.unsubscribe( tokenOrFunction ) -> String | Boolean
+     *  - tokenOrFunction (String|Function): The token of the function to unsubscribe or func passed in on subscribe
+     *  Unsubscribes a specific subscriber from a specific message using the unique token
+     *  or if using Function as argument, it will remove all subscriptions with that function
+    **/
+    PubSub.unsubscribe = function( tokenOrFunction ){
+        var isToken = typeof tokenOrFunction === 'string',
+            result = false,
+            m, message, t, token;
+
+        for ( m in messages ){
+            if ( messages.hasOwnProperty( m ) ){
+                message = messages[m];
+
+                if ( isToken && message[tokenOrFunction] ){
+                    delete message[tokenOrFunction];
+                    result = tokenOrFunction;
+                    // tokens are unique, so we can just stop here
+                    break;
+                } else if (!isToken) {
+                    for ( t in message ){
+                        if (message.hasOwnProperty(t) && message[t] === tokenOrFunction){
+                            delete message[t];
+                            result = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
+    };
+
+    return PubSub;
+}));

--- a/javascript/tool/js/d3-tip.js
+++ b/javascript/tool/js/d3-tip.js
@@ -1,0 +1,320 @@
+// d3.tip
+// Copyright (c) 2013 Justin Palmer
+// ES6 / D3 v4 Adaption Copyright (c) 2016 Constantin Gavrilete
+// Removal of ES6 for D3 v4 Adaption Copyright (c) 2016 David Gotz
+//
+// Tooltips for d3.js SVG visualizations
+
+d3.functor = function functor(v) {
+  return typeof v === "function" ? v : function() {
+    return v;
+  };
+};
+
+d3.tip = function() {
+
+  var direction = d3_tip_direction,
+      offset    = d3_tip_offset,
+      html      = d3_tip_html,
+      node      = initNode(),
+      svg       = null,
+      point     = null,
+      target    = null
+
+  function tip(vis) {
+    svg = getSVGNode(vis)
+    point = svg.createSVGPoint()
+    document.body.appendChild(node)
+  }
+
+  // Public - show the tooltip on the screen
+  //
+  // Returns a tip
+  tip.show = function() {
+    var args = Array.prototype.slice.call(arguments)
+    if(args[args.length - 1] instanceof SVGElement) target = args.pop()
+
+    var content = html.apply(this, args),
+        poffset = offset.apply(this, args),
+        dir     = direction.apply(this, args),
+        nodel   = getNodeEl(),
+        i       = directions.length,
+        coords,
+        scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
+        scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+
+    nodel.html(content)
+      .style('position', 'absolute')
+      .style('opacity', 1)
+      .style('pointer-events', 'all')
+
+    while(i--) nodel.classed(directions[i], false)
+    coords = direction_callbacks[dir].apply(this)
+    nodel.classed(dir, true)
+      .style('top', (coords.top +  poffset[0]) + scrollTop + 'px')
+      .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
+
+    return tip
+  }
+
+  // Public - hide the tooltip
+  //
+  // Returns a tip
+  tip.hide = function() {
+    var nodel = getNodeEl()
+    nodel
+      .style('opacity', 0)
+      .style('pointer-events', 'none')
+    return tip
+  }
+
+  // Public: Proxy attr calls to the d3 tip container.  Sets or gets attribute value.
+  //
+  // n - name of the attribute
+  // v - value of the attribute
+  //
+  // Returns tip or attribute value
+  tip.attr = function(n, v) {
+    if (arguments.length < 2 && typeof n === 'string') {
+      return getNodeEl().attr(n)
+    } else {
+      var args =  Array.prototype.slice.call(arguments)
+      d3.selection.prototype.attr.apply(getNodeEl(), args)
+    }
+
+    return tip
+  }
+
+  // Public: Proxy style calls to the d3 tip container.  Sets or gets a style value.
+  //
+  // n - name of the property
+  // v - value of the property
+  //
+  // Returns tip or style property value
+  tip.style = function(n, v) {
+    // debugger;
+    if (arguments.length < 2 && typeof n === 'string') {
+      return getNodeEl().style(n)
+    } else {
+      var args = Array.prototype.slice.call(arguments);
+      if (args.length === 1) {
+        var styles = args[0];
+        Object.keys(styles).forEach(function(key) {
+          return d3.selection.prototype.style.apply(getNodeEl(), [key, styles[key]]);
+        });
+      }
+    }
+
+    return tip
+  }
+
+  // Public: Set or get the direction of the tooltip
+  //
+  // v - One of n(north), s(south), e(east), or w(west), nw(northwest),
+  //     sw(southwest), ne(northeast) or se(southeast)
+  //
+  // Returns tip or direction
+  tip.direction = function(v) {
+    if (!arguments.length) return direction
+    direction = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: Sets or gets the offset of the tip
+  //
+  // v - Array of [x, y] offset
+  //
+  // Returns offset or
+  tip.offset = function(v) {
+    if (!arguments.length) return offset
+    offset = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: sets or gets the html value of the tooltip
+  //
+  // v - String value of the tip
+  //
+  // Returns html value or tip
+  tip.html = function(v) {
+    if (!arguments.length) return html
+    html = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: destroys the tooltip and removes it from the DOM
+  //
+  // Returns a tip
+  tip.destroy = function() {
+    if(node) {
+      getNodeEl().remove();
+      node = null;
+    }
+    return tip;
+  }
+
+  function d3_tip_direction() { return 'n' }
+  function d3_tip_offset() { return [0, 0] }
+  function d3_tip_html() { return ' ' }
+
+  var direction_callbacks = {
+    n:  direction_n,
+    s:  direction_s,
+    e:  direction_e,
+    w:  direction_w,
+    nw: direction_nw,
+    ne: direction_ne,
+    sw: direction_sw,
+    se: direction_se
+  };
+
+  var directions = Object.keys(direction_callbacks);
+
+  function direction_n() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.n.y - node.offsetHeight,
+      left: bbox.n.x - node.offsetWidth / 2
+    }
+  }
+
+  function direction_s() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.s.y,
+      left: bbox.s.x - node.offsetWidth / 2
+    }
+  }
+
+  function direction_e() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.e.y - node.offsetHeight / 2,
+      left: bbox.e.x
+    }
+  }
+
+  function direction_w() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.w.y - node.offsetHeight / 2,
+      left: bbox.w.x - node.offsetWidth
+    }
+  }
+
+  function direction_nw() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.nw.y - node.offsetHeight,
+      left: bbox.nw.x - node.offsetWidth
+    }
+  }
+
+  function direction_ne() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.ne.y - node.offsetHeight,
+      left: bbox.ne.x
+    }
+  }
+
+  function direction_sw() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.sw.y,
+      left: bbox.sw.x - node.offsetWidth
+    }
+  }
+
+  function direction_se() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.se.y,
+      left: bbox.e.x
+    }
+  }
+
+  function initNode() {
+    var node = d3.select(document.createElement('div'))
+    node
+      .style('position', 'absolute')
+      .style('top', 0)
+      .style('opacity', 0)
+      .style('pointer-events', 'none')
+      .style('box-sizing', 'border-box')
+
+    return node.node()
+  }
+
+  function getSVGNode(el) {
+    el = el.node()
+    if(el.tagName.toLowerCase() === 'svg')
+      return el
+
+    return el.ownerSVGElement
+  }
+
+  function getNodeEl() {
+    if(node === null) {
+      node = initNode();
+      // re-add node to DOM
+      document.body.appendChild(node);
+    };
+    return d3.select(node);
+  }
+
+  // Private - gets the screen coordinates of a shape
+  //
+  // Given a shape on the screen, will return an SVGPoint for the directions
+  // n(north), s(south), e(east), w(west), ne(northeast), se(southeast), nw(northwest),
+  // sw(southwest).
+  //
+  //    +-+-+
+  //    |   |
+  //    +   +
+  //    |   |
+  //    +-+-+
+  //
+  // Returns an Object {n, s, e, w, nw, sw, ne, se}
+  function getScreenBBox() {
+    var targetel   = target || d3.event.target;
+
+    while ('undefined' === typeof targetel.getScreenCTM && 'undefined' === targetel.parentNode) {
+        targetel = targetel.parentNode;
+    }
+
+    var bbox       = {},
+        matrix     = targetel.getScreenCTM(),
+        tbbox      = targetel.getBBox(),
+        width      = tbbox.width,
+        height     = tbbox.height,
+        x          = tbbox.x,
+        y          = tbbox.y
+
+    point.x = x
+    point.y = y
+    bbox.nw = point.matrixTransform(matrix)
+    point.x += width
+    bbox.ne = point.matrixTransform(matrix)
+    point.y += height
+    bbox.se = point.matrixTransform(matrix)
+    point.x -= width
+    bbox.sw = point.matrixTransform(matrix)
+    point.y -= height / 2
+    bbox.w  = point.matrixTransform(matrix)
+    point.x += width
+    bbox.e = point.matrixTransform(matrix)
+    point.x -= width / 2
+    point.y -= height / 2
+    bbox.n = point.matrixTransform(matrix)
+    point.y += height
+    bbox.s = point.matrixTransform(matrix)
+
+    return bbox
+  }
+
+  return tip
+};

--- a/javascript/tool/js/housing-insights.js
+++ b/javascript/tool/js/housing-insights.js
@@ -1,0 +1,75 @@
+'use strict';
+
+// I'm not using ES6 syntax (e.g. const, let). Happy to do so if we determine it has enough browser support for the project.
+
+var app = {
+    dataCollection: {},
+    getData: function(DATA_FILE,dataName,el,field,sortField,asc,chart,readableField){
+        d3.csv(DATA_FILE, function(json) {
+            json.forEach(function(obj) { // iterate over each object of the data array
+                for (var key in obj) {   // iterate over each property of the object
+                    if (obj.hasOwnProperty(key)) {  // forEach iterates over protypical property.
+                                                    // hasOwnProperty limits to own, nonprototypical properties.
+                        obj[key] = isNaN(+obj[key]) ? obj[key] : +obj[key]; // + operator converts to number unless result would be NaN
+                    }
+                }
+            });
+            app.dataCollection[dataName] = json;
+            console.log(app.dataCollection);
+            // publish a topic asyncronously (module allows for asynch publishing which may be faster but can cause problems)
+            PubSub.publish( dataName + '/load', '' ); // using the publish/subscribe module provided in local PubSubs.js
+                                                          // source: https://github.com/mroderick/PubSubJS
+                                                          // param1 = topic; param 2 = message
+                                                          // using here to publish that data has been loaded so that 
+                                                          // other Charts using the same data can be initiated  
+            chart.initialSetup(dataName,el,field,sortField,asc,readableField);
+        });
+    }
+};
+    
+var Chart = function(DATA_FILE,dataName,el,field,sortField,asc,readableField) {
+    this.initialize(DATA_FILE,dataName,el,field,sortField,asc,readableField); 
+};
+
+Chart.prototype = {
+    data: [],
+    initialize: function(DATA_FILE,dataName,el,field,sortField,asc,readableField) { // parameters will be passed by the call to the specific chart type         
+        
+        var chart = this; // so that `this` can be passed as parameter to app.getData
+        if (DATA_FILE) { // if DATA_FILE param is not null, fetch new data
+                         // and assign it to the app.dataCollection under name dataName
+            app.getData(DATA_FILE,dataName,el,field,sortField,asc,chart,readableField);
+        } else {         // if DATA_FILE is null proceed to intialSetup where data is defined as existing array
+                         // with name dataName in the app.dataCollection object
+            this.initialSetup(dataName,el,field,sortField,asc,readableField);
+        }
+    },
+    initialSetup: function(dataName,el,field,sortField,asc,readableField){
+       console.log(app.dataCollection[dataName]);
+       this.data = app.dataCollection[dataName]; 
+       var data = this.data;
+       
+       data.sort(function(a, b) { // sorting data array with JS prototype sort function
+            if (asc) return a[sortField] - b[sortField]; // if asc parameter in Chart constructor call is true
+            return b[sortField] - a[sortField]; // if not
+          });  
+       this.minValue = d3.min(data, function(d) { // d3.min iterates through datums (d) and return the smallest
+            return d[field]
+        });
+
+       this.maxValue = d3.max(data, function(d) { // d3.max iterates through datums (d) and return the largest
+            return d[field]
+        });
+       this.setup(el, field, sortField, asc, readableField); 
+console.log(this.minValue);
+console.log(this.maxValue);
+    },
+                      // ex: MovingBlockChart.prototype (param[0])
+    extendPrototype: function(destinationPrototype, obj){ // using this function for inheritance. 
+                                                          // extend a constructor's prototype with the keys/values in obj. 
+
+       for(var i in obj){
+          destinationPrototype[i] = obj[i];
+      } 
+    } // end extendPrototype
+}; // end Chart.prototype

--- a/javascript/tool/js/moving-blocks.js
+++ b/javascript/tool/js/moving-blocks.js
@@ -1,0 +1,201 @@
+"use strict";
+var SQUARE_WIDTH = 10, // symbolic constants all caps following convention
+    SQUARE_SPACER = 2,
+    ROWS = 12;
+
+var MovingBlockChart = function(DATA_FILE, dataName, el, field, sortField, asc, readableField) { // set text of tooltip with 'readableField' arg
+    Chart.call(this, DATA_FILE, dataName, el, field, sortField, asc, readableField); // First step of inheriting from Chart
+    this.extendPrototype(MovingBlockChart.prototype, movingBlockExtension);
+}
+
+MovingBlockChart.prototype = Object.create(Chart.prototype);
+
+var movingBlockExtension = { // Final step of inheriting from Chart.
+    setup: function(el, field, sortField, asc, readableField){
+        var chart = this,
+            data = chart.data // chart.data (this.data) is set in the Chart prototype, taken from app.dataCollection[dataName] 
+            var tool_tip = d3.tip()
+                .attr("class", "d3-tip")
+                .offset([-8, 0])
+                .direction('e')
+                .html(function(d){
+                    return '<b>' + d.Proj_Name + '<br>' + d.Proj_Addre + '</b><br><br>' + readableField + ': ' + d[field];  //here the text of the tooltip is hard coded in but we'll need a human-readable field in the data to provide that text
+                  });
+                  console.log(data);
+// chart.svg was in the Chart prototype, but better now to have it in specific prototypes
+        chart.svg = d3.select(el) // select elem (div#chart-0)
+                .append('svg')        // append svg element 
+                .attr('width', 100 + '%')   // d3 v4 requires setting attributes one at a time. no native support for setting attr or style with objects as in v3. this library would make it possible: mini library D3-selection-mult
+                .attr('height', 200); // SVG object dimensions are hard-coded now, but it may be 
+                                      // useful to set these as, say, a parameter in constructors that
+                                      // inherit from Chart.
+         
+        chart.svg.selectAll('rect') // selects svg element `rect`s whether they exist yet or not          
+            .data(data) // binds to data
+            .enter() // for all `rect`s that don't yet exist
+            .append('rect') // create the `rect`
+            .attr('width', SQUARE_WIDTH)
+            .attr('height', SQUARE_WIDTH)
+     //  removed setting fill attribute here in favor of setting it in CSS
+            .attr('fill-opacity', 0.1)
+            .attr('data-index', function(d, i){
+              return i; // for debugging purposes
+            })               
+            .on('mouseover', tool_tip.show) // .show is defined in links d3-tip library
+            .on('mouseout', tool_tip.hide)  // .hide is defined in links d3-tip library
+            .call(tool_tip);
+
+    // chart.scale was defined in Chart prototype but now in specific prototype
+        chart.scale = d3.scaleLinear().domain([chart.minValue, chart.maxValue]).range([0.1, 1]);
+        chart.positionBlocks(0);
+        chart.changeOpacity(field);
+
+        chart.buttonRand = d3.select(el) // creates the button to randomly resort and appends it in the el (div#chart-0)
+            .append('button')
+            .text('Resort randomly')
+            .on('click', function(){
+                chart.resort('random');
+            });
+
+        chart.buttonZip = d3.select(el) // creates the button to randomly resort and appends it in the el (div#chart-0)
+            .append('button')
+            .text('Resort by zip')
+            .on('click', function(){
+                chart.resort('Proj_Zip');
+            });
+
+        chart.buttonUnit = d3.select(el) // creates the button to randomly resort and appends it in the el (div#chart-0)
+            .append('button')
+            .text('Resort by value')
+            .on('click', function(){
+                chart.resort(field);
+            });
+
+        chart.slider = d3.select(el)
+            .append('input')
+            .attr('type', 'range')
+            .attr('id', 'inputSlider')
+            .attr('step', '.01')      // .01 is kind of a magic number and probably should be made responsive to the data
+            .style('margin-top', '1em') // these two style elements are pretty arbitrary
+            .style('width', '40%');
+            
+
+        d3.select('#inputSlider')
+            .attr('min', chart.minValue)
+            .attr('max', chart.maxValue);
+
+        chart.slider.on('mousedown', function(){ // this anonymous function wraps
+                 chart.sliderAction(field);  // another function in order to pass a
+            }, false);                      // parameter despite being an event listener
+
+    },  // end setup()
+
+    positionBlocks: function(duration){
+                
+        this.svg.selectAll('rect')
+            .transition().duration(duration)
+            .attr('y', function(d, i) {
+                return (i * SQUARE_WIDTH + SQUARE_SPACER * i) - Math.floor(i / ROWS) * (SQUARE_WIDTH + SQUARE_SPACER) * ROWS;
+            }) // horizontal placement is function of the index and the number of ROWS desired
+            .attr('x', function(d, i) {
+                return Math.floor(i / ROWS) * SQUARE_WIDTH + (Math.floor(i / ROWS) * SQUARE_SPACER);
+            }) // vertical placement function of index and number of columns. Math.floor rounds down to nearest integer
+    }, // end positionBlocks
+
+    changeOpacity: function(field){
+      var chart = this;
+      chart.svg.selectAll('rect')
+     
+      .transition().delay(250).duration(750)
+      .attr('fill-opacity', function(d, i, array) { // opacity is a function of the value
+          var value;
+          if (isNaN(d[field])) { // some fields have NaN values and d3.sort was puuting them in the middle of the range
+            value = 0;           // this sorts them as if their value was zero and also adds a null-value class to `rect`
+                                 //  so that it can be styled appropriately
+            array[i].setAttribute('class', 'null-value');
+          } else {
+            value = chart.scale(d[field]);
+          }
+          
+          return value;
+      }) 
+    },
+
+    resort: function(value){
+
+        /* for demo purposes only. production tool will have many events that trigger update and 
+         * (potentially) resort functions. probably best and easiest to eventually  use an observer pattern
+         * or pub/sub (publish/subscribe) (same thing?) pattern to connect user- ot client-inititiated events (including resize)
+         * with update functions
+         */
+          var chart = this;
+          console.log(value);
+          
+      if (value === 'random') {
+        this.svg.selectAll('rect').sort(function(a, b){
+                return d3.ascending(Math.random(), Math.random());
+            });
+      } else {
+         this.svg.selectAll('rect').sort(function(a, b){
+                var aProxy = (isNaN(a[value])) ? -1 : a[value];
+                var bProxy = (isNaN(b[value])) ? -1 : b[value];
+                return d3.ascending(aProxy, bProxy);
+            });
+
+      }
+     
+        this.positionBlocks(500);
+
+    }, // end resort()
+
+    sliderAction: function(field){
+                    document.querySelector('body').addEventListener('mousemove', checkColors, false);
+                
+                    function checkColors(event) {
+                        console.log(event);
+                        let value = document.querySelector('#inputSlider').value;
+                        d3.selectAll('rect').attr('class', function(d){
+                          if(d[field] < value){ // threshold now sets class of `rect` rather than hard-coding in value
+                            return 'under-threshold';
+                          } else {
+                            return '';
+                          }
+                        });
+
+                        d3.select('body').on('mouseup', function(){
+                            document.querySelector('body').removeEventListener('mousemove', checkColors);
+                        }, false);
+                    };  
+    }       // end sliderAction()
+
+}; // end prototype
+
+/*
+ * Constructor calls below. First done inline; second only when the data from the first is available, using PubSub module 
+ */
+
+var DATA_FILE = 'https://raw.githubusercontent.com/codefordc/housing-insights/dev/scripts/small_data/PresCat_Export_20160401/Project.csv';
+
+// first Chart loads new data
+new MovingBlockChart(DATA_FILE,'projectCSV','#chart-0','Proj_Units_Tot','Proj_Zip',false,'Total Units'); 
+
+// second chart uses the same data as first. its constructor is wrapper is a function subscribed
+// to the publishing of the data being loaded. using this pattern, we can have several charts on a 
+// page based on the same data
+
+// wrapper function
+var subscriber1 = function( msg, data ){ // for now the subscribed function directly calls the Chart constructor but
+                                          // in future we could have it look for all constructors waiting to be called,
+                                          // defined elsewhere
+    console.log( msg, data );
+    new MovingBlockChart(null,'projectCSV','#chart-1','Proj_Units_Tot','Proj_Units_Tot',true,'Total Units'); // second Chart uses same data 
+                                                                                             // as first. Needs to wait until
+                                                                                             // that data is loaded before being
+                                                                                             // initiated.
+
+};
+
+// add the function to the list of subscribers for a particular topic (projectCSV/load in this case)
+// we're keeping the returned token, in order to be able to unsubscribe
+// from the topic later on (probably not necessary for us, not yet at least)
+var token = PubSub.subscribe( 'projectCSV/load', subscriber1 );

--- a/javascript/tool/moving-blocks.html
+++ b/javascript/tool/moving-blocks.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Moving Blocks</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.4.1/d3.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="css/moving-blocks.css">
+
+</head>
+<body>
+  <header>
+    <h1>Moving Blocks</h1>
+  </header>
+  <section>
+    <div id="chart-0" class="d3-chart"></div>    
+  </section>
+  <section>
+    <div id="chart-1" class="d3-chart"></div>    
+  </section>
+  <script src="js/d3-tip.js"></script>
+  <script src="js/PubSub.js"></script>
+  <script src="js/housing-insights.js"></script>
+  <script src="js/moving-blocks.js"></script>
+</body>
+</html>


### PR DESCRIPTION
… new file structure

@NealHumphrey: Branch was protected from direct push, so I'm making a pull request

Description:
Takes the scripts necessary for all Charts and puts that into housing-insights.js. Removes the IIFE structure so methods and variables are accessible across files. All test projects should link to this file before their own chart-specific scripts.

Housing-insights.js handles the initializing and initial setup of Charts, with the option of fetching new data or using data that another Chart has already fetched. Uses a pub/sub module to publish when certain data is loaded so that subsequent, subscribe constructors can fire only when that data is ready.

This PR also recreate the moving-block prototype in moving-blocks.html. The scripts in moving-blocks.js should serve as an example of how to inherit from Chart in housing-insights.js, how to use the pub/sub, and how to call new constructors. 