### PR TITLE
Adding the beginnings of code for feeding building data into Mapbox maps for the building page

### DIFF
--- a/javascript/tool/js/building-map.js
+++ b/javascript/tool/js/building-map.js
@@ -49,17 +49,37 @@
       center: thisBuildingLayer['data']['geometry']['coordinates'],
       zoom: 16
     });
-    
-  // Guidance on adding layers is here: https://www.mapbox.com/mapbox-gl-js/style-spec/#layers
-  // FOR ACTION, ERROR TO FIX - currently receiving error message, 'Error: Style is not 
-  // done loading' from mapbox-gl.js:127.
-    map.addLayer({
-      id: "buildingLocation",
-      source: thisBuildingLayer,
-      type: "circle",
-      minzoom: 11,
+
+    // Guidance on adding layers is here: https://www.mapbox.com/mapbox-gl-js/style-spec/#layers
+    // The 'on()' function below appears to be a method of a Mapbox map, though there's no entry
+    // for 'on()' in the Mapbox JS GL API.
+    // Information on styling layers is here:
+    // https://www.mapbox.com/mapbox-gl-js/style-spec/#layer-paint
+    map.on('load', function(){
+      map.addLayer({
+        'id': "buildingLocation",
+        'source': thisBuildingLayer,
+        'type': "circle",
+        'minzoom': 11,
+        'paint': {
+          'circle-color': 'rgb(120,150,255)',
+          'circle-stroke-width': 3,
+          'circle-stroke-color': 'rgb(150,150,150)',
+          'circle-radius': 10
+        }
+      });
+      map.addLayer({
+        'id': "buildingTitle",
+        'source': thisBuildingLayer,
+        'type': "symbol",
+        'minzoom': 11,
+        'layout': {
+          'text-field': "{Proj_Name}",
+          'text-anchor': "bottom-left"
+        }
+      });
     });
-  
+        
   }
   
   window.addEventListener('load', function(){


### PR DESCRIPTION
### Something to review
In the building page, I'm working on a way to grab data for Mapbox maps. As shown in the building page prototype, we're displaying various layers of data (probably geoJSON) on Mapbox maps: layers of public transport, other public housing, building permits and so on. I was thinking of using app.getData() to do this, grabbing the .csv files that we use for Charts and manipulating the data into geoJSON (if it's not in that format already). This way, I could add geoJSON layers to Mapbox maps while sharing data with any other Charts that needed it. 

There's a possible issue here: the parameters of app.getData() currently assume that we will be using the data for a Chart. In the comments I've suggested two possibilities, either (a) adjusting app.getData() to work with both Charts and Mapbox objects; or (b) having Mapbox maps make separate requests, pulling geoJSON straight from the server. Let me know which you prefer and I can add to my '80-map-on-building-page' branch.

### A more general possibility
Since different Charts (or Mapbox maps) will be on different pages of the site, we could think about putting the 'app' object in some kind of client-side storage, e.g. [Window.sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). This way a user could, say, access the moving block chart, then access the building page, reusing the data from the former for the latter without the code having to process the .csv file again.