### PR TITLE
In the building page, in the sample Mapbox map, add a layer of dots f…

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,0 +1,44 @@
+GEM
+  specs:
+    addressable (2.4.0)
+    colorator (1.1.0)
+    ffi (1.9.14)
+    forwardable-extended (2.6.0)
+    jekyll (3.3.1)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.13.2)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.4.22)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (= 3.3.1)
+
+BUNDLED WITH
+   1.14.2

--- a/javascript/tool/building.html
+++ b/javascript/tool/building.html
@@ -1,4 +1,4 @@
-<%=  %><!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -77,8 +77,18 @@
       </section>
       <section class="tile" id="map-tile">
         <!-- Paul's stuff -->
-        <div class="map-wrapper" style="margin: 50px 0px 0px 80px;">
-          <div class="mapbox-portal" id="test-map"></div>
+        <div class="container">
+          <div class = "row">
+            <h3 class = "col-sm-12">Affordable housing nearby</h2>
+          </div>
+          <div class = "row">
+            <div class = "col-sm-6">
+              <div class="mapbox-portal" id="test-map"></div>
+            </div>
+            <div class = "col-sm-6">
+              Here's some test text.
+            </div>
+          </div>
         </div>
       </section>
     </section>

--- a/javascript/tool/css/building.css
+++ b/javascript/tool/css/building.css
@@ -1,8 +1,5 @@
 .mapbox-portal{
-  height: 80%;
   min-height: 300px;
-  width: 50%;
-  min-width: 450px;
 }
 
 .building-info-block {

--- a/javascript/tool/js/building-map.js
+++ b/javascript/tool/js/building-map.js
@@ -1,108 +1,78 @@
 (function prepareBuildingMaps(){
   'use strict'
   
-  // FOR ACTION - determine how to bind building data to a building page. 
-  // Will it be in the JS when the user selects a building to display (i.e. via AJAX)? 
-  // Or when producing the document from a template on the server?
+  // WHERE THE DATA CURRENTLY COME FROM:
+  // District of Columbia Open Data, which is here: 
+  //   http://opendata.dc.gov, the public housing dataset.
+  // This dataset is for development purposes only.
   
-  var thisBuildingLayer,
-      MapboxPortal,
-      prepareGeoJSON; // FOR REVIEW: prepareGeoJSON (see below)
+  var MapboxPortal,
+      DATASET_URL = "http://opendata.dc.gov/datasets/34ae3d3c9752434a8c03aca5deb550eb_62.geojson",
+      // dataset will likely be temporary, given that we will use other datasets!
+      dataset,
+      grabData,
+      prepareSource,
+      prepareMaps,
+      thisBuildingSource,
+      mapboxSource,
+  // NOTE: Until we have a backend that identifies the building a user has chosen to look at
+  // (or accomplish this with AJAX), buildingForPage specifies the building that the page is
+  // based around and points to dataset['features'][0];
+      buildingForPage;
   
-  
-  // FOR REVIEW - prepareGeoJSON takes a single flat object, i.e. an object in which no
-  // value is another object, and turns it into a geoJSON object based on the keys that
-  // are specified to represent longitude and latitude.
-  // So far this function only exists to work with Project.csv and app.dataCollection.
-  // It may no longer be useful if the plan is to load geoJSON directly from the server.
-
-  // SO FAR NOTHING CALLS THIS. Paul's goal was to use prepareGeoJSON to manipulate Project.csv 
-  // after processing it within app.getData() and storing it in app.dataCollection.
-  // Currently, app.getData() assumes that the data will be used in a Chart.
-  // POSSIBLE SOLUTIONS: 
-  // a- Make app.getData() work for both Charts and non-Chart objects (like Mapbox maps) that
-  //    use the same data. Remove some parameters from app.getData, including Chart.
-  // b- Keep MapboxPortals separate from the app/Chart relationship. MapboxPortals make their
-  //    own requests for geoJSON objects.
-  prepareGeoJSON = function(obj, longKey, latKey){
-    // Some keys of the resulting geoJSON object are hard-coded (see below). In the future
-    // we may want to extract them as parameters of prepareGeoJSON().
-    // Coordinates are added later.
-    var resultingObj = {
-      type: "Feature",
-      geometry: {
-        type: "Point",
-        coordinates: [obj[longKey], obj[latKey]]        
-      },
-      properties: {}
-    };
-    
-    // The 'select' call and 'for' loop iterate over any properties of obj that aren't
-    // specified as longitude and latitude, adding them to the 'properties' property
-    // of the resulting geoJSON object.
-    var propertyKeys = Object.keys(obj).select(function(key){
-      return key != longKey && key != latKey;
-    });    
-    
-    for(var i = 0; i < propertyKeys.length; i++){
-      resultingObj['properties'][propertyKeys[i]] = obj[propertyKeys[i]];
-    }
-    
-    return resultingObj;      
-  }
-  
-        
-  // The geoJSON object in thisBuildingLayer['data'] comes from 
-  // one row within '/scripts/small_data/PresCat_Export_20160401/Project.csv'.
-  // This is for exploratory purposes only, pending a way to load the building information 
-  // dynamically.
-      
-  // thisBuildingLayer is an object containing a layer source as per 
-  // https://www.mapbox.com/mapbox-gl-js/style-spec/#layers
-  
-  thisBuildingLayer = {
-    type: "geojson",
-    data: {
-      type: "Feature",
-      geometry: { 
-        type: "Point",
-        coordinates: [-77.0511477, 38.89886317]
-      },
-    // These are some properties from '/scripts/small_data/PresCat_Export_20160401/Project.csv'.
-    // So far they are just for illustration. 
-      properties: { 
-        Proj_Name: "St. Mary's Court", 
-        Proj_Addre: "725 24th Street NW", 
-        Proj_City: "Washington", 
-        Proj_ST: "DC", 
-        Proj_Zip: 20037, 
-        Proj_Units_Tot: 140, 
-        Proj_Units_Assist_Min: 140, 
-        Proj_Units_Assist_Max: 140
+  grabData = function(callback){
+    var req = new XMLHttpRequest();
+    req.open('GET', DATASET_URL);
+    req.send();
+    req.onreadystatechange = function(){
+      if(req.readyState == 4){
+        return callback(req.responseText);
       }
-    }  
+    }
   }
   
-  MapboxPortal = function (elementID){
-  // So far the style url and access token come from Paul's Mapbox account.
-  // FOR ACTION - find an accessToken that works for everyone.
-    mapboxgl.accessToken = 'pk.eyJ1IjoicGF1bGdvdHRzY2hsaW5nIiwiYSI6ImNpejF1Y2U3MzA1ZmQzMnA4c3N4a3FkczgifQ.6W04v2jEJFkZvVhOI-yL6A'
-    var map = new mapboxgl.Map({
-      container: elementID,
-      style: 'mapbox://styles/mapbox/streets-v9',
-      center: thisBuildingLayer['data']['geometry']['coordinates'],
-      zoom: 16
-    });
+  // The below function turns a geoJSON object into a source object for Mapbox maps.
+  // The second argument determines whether to exclude the building page's target
+  // building from the data.
+  // FOR REVIEW - prepareSource seems to want to be a constructor.
+  //                     geoJSON object    boolean
+  prepareSource = function(dat, excludeThisBuilding){
+    var dat = dat;
+        
+    if(excludeThisBuilding && dat['type'] == 'FeatureCollection'){ 
+      dat['features'] = dat['features'].filter(function(element){
+      // The assumption here is that a given feature will be identical to the target building
+      // if it has the exact same coordinates.
+        return (
+          element['geometry']['coordinates'][0] != buildingForPage['geometry']['coordinates'][0] &&
+          element['geometry']['coordinates'][1] != buildingForPage['geometry']['coordinates'][1]
+        )
+      });
+    }
+    return {
+      type: 'geojson',
+      data: dat
+    }
+  }
+  
+  prepareMaps = function(ajaxResponseText){
 
-    // Guidance on adding layers is here: https://www.mapbox.com/mapbox-gl-js/style-spec/#layers
-    // The 'on()' function below appears to be a method of a Mapbox map, though there's no entry
-    // for 'on()' in the Mapbox JS GL API.
-    // Information on styling layers is here:
-    // https://www.mapbox.com/mapbox-gl-js/style-spec/#layer-paint
-    map.on('load', function(){
+    // FOR ACTION - we will need to change this assignment Of dataset once we start using other datasets.
+    dataset = JSON.parse(ajaxResponseText);
+    
+    // FOR ACTION - we will need another way to specify the building that is the subject of the building page.
+    buildingForPage = dataset['features'][0];
+    
+    console.log(dataset['features'][0]);
+    mapboxSource = prepareSource(dataset, true);
+    thisBuildingSource = prepareSource(buildingForPage, false);
+
+    
+    new MapboxPortal('test-map', function(map){
+          
       map.addLayer({
         'id': "buildingLocation",
-        'source': thisBuildingLayer,
+        'source': mapboxSource,
         'type': "circle",
         'minzoom': 11,
         'paint': {
@@ -114,21 +84,69 @@
       });
       map.addLayer({
         'id': "buildingTitle",
-        'source': thisBuildingLayer,
+        'source': mapboxSource,
         'type': "symbol",
         'minzoom': 11,
         'layout': {
-          'text-field': "{Proj_Name}",
+          'text-field': "{PROJECT_NAME}",
           'text-anchor': "bottom-left"
         }
       });
     });
+  }
+
+  // The MapboxPortal constructor inserts a Mapbox map into element with elementID.
+  // It always adds certain layers (the dot and label for the building-of-interest).
+  // For additional layers, name a function in onloadCAllback. The function will
+  // take the Mapbox map as an argument. 
+  MapboxPortal = function (elementID, onloadCallback){
+  // So far the style url and access token come from Paul's Mapbox account.
+  // FOR ACTION - find an accessToken that works for everyone.
+    mapboxgl.accessToken = 'pk.eyJ1IjoicGF1bGdvdHRzY2hsaW5nIiwiYSI6ImNpejF1Y2U3MzA1ZmQzMnA4c3N4a3FkczgifQ.6W04v2jEJFkZvVhOI-yL6A'
+    var map = new mapboxgl.Map({
+      container: elementID,
+      style: 'mapbox://styles/mapbox/streets-v9',
+      center: buildingForPage['geometry']['coordinates'],
+      zoom: 16
+    });
+    
+    // Guidance on adding layers is here: https://www.mapbox.com/mapbox-gl-js/style-spec/#layers
+    // The 'on()' function below appears to be a method of a Mapbox map, though there's no entry
+    // for 'on()' in the Mapbox JS GL API.
+    // Information on styling layers is here:
+    // https://www.mapbox.com/mapbox-gl-js/style-spec/#layer-paint
+    map.on('load', function(){
+      
+      map.addLayer({
+        'id': "thisBuildingLocation",
+        'source': thisBuildingSource,
+        'type': 'circle',
+        'minzoom': 11,
+        'paint': {
+          'circle-color': 'red',
+          'circle-stroke-width': 3,
+          'circle-stroke-color': 'red',
+          'circle-radius': 10
+        }
+      });
+      
+      map.addLayer({
+        'id': "thisBuildingTitle",
+        'source': thisBuildingSource,
+        'type': "symbol",
+        'minzoom': 11,
+        'layout': {
+          'text-field': "{PROJECT_NAME}",
+          'text-anchor': "bottom-left"
+        }
+      });
+      
+      if(onloadCallback){ onloadCallback(map); }
+      
+    });
         
   }
-  
-  window.addEventListener('load', function(){
-    console.log("The document has loaded!");
-    new MapboxPortal('test-map');
-  });
+    
+  grabData(prepareMaps);
   
 })();


### PR DESCRIPTION
…or all public housing and another layer for the development in question.

Position elements of a panel within the building page using Bootstrap

Make parts of MapboxPortal (building-map.js) more extensible

Make it possible to remove the target building from a Mapbox source when layering sources on the building page