### PR TITLE
Handle multiple data sources in the building information page

### DIFF
--- a/javascript/tool/building.html
+++ b/javascript/tool/building.html
@@ -83,13 +83,27 @@
           </div>
           <div class = "row">
             <div class = "col-sm-6">
-              <div class="mapbox-portal" id="test-map"></div>
+              <div class="mapbox-portal" id="affordable-housing-map"></div>
             </div>
             <div class = "col-sm-6">
               Here's some test text.
             </div>
           </div>
         </div>
+        <div class="container">
+          <div class = "row">
+            <h3 class = "col-sm-12">Metro stations nearby</h2>
+          </div>
+          <div class = "row">
+            <div class = "col-sm-6">
+              <div class="mapbox-portal" id="metro-stations-map"></div>
+            </div>
+            <div class = "col-sm-6">
+              Here's some test text.
+            </div>
+          </div>
+        </div>
+
       </section>
     </section>
 

--- a/javascript/tool/js/building-map.js
+++ b/javascript/tool/js/building-map.js
@@ -70,13 +70,38 @@
     }
   }
   
+  // The MapboxPortal constructor inserts a Mapbox map into element with elementID.
+  // It always adds certain layers (the dot and label for the building-of-interest).
+  // For additional layers, name a function in onloadCAllback. The function will
+  // take the Mapbox map as an argument. 
+  MapboxPortal = function (elementID, layersArray){
+  // So far the style url and access token come from Paul's Mapbox account.
+  // FOR ACTION - find an accessToken that works for everyone.
+    mapboxgl.accessToken = 'pk.eyJ1IjoicGF1bGdvdHRzY2hsaW5nIiwiYSI6ImNpejF1Y2U3MzA1ZmQzMnA4c3N4a3FkczgifQ.6W04v2jEJFkZvVhOI-yL6A'
+    var map = new mapboxgl.Map({
+      container: elementID,
+      style: 'mapbox://styles/mapbox/streets-v9',
+      center: buildingForPage['geometry']['coordinates'],
+      zoom: 16
+    });
+    
+    // Guidance on adding layers is here: https://www.mapbox.com/mapbox-gl-js/style-spec/#layers
+    // The 'on()' function below appears to be a method of a Mapbox map, though there's no entry
+    // for 'on()' in the Mapbox JS GL API.
+    // Information on styling layers is here:
+    // https://www.mapbox.com/mapbox-gl-js/style-spec/#layer-paint
+    map.on('load', function(){
+      for(var i = 0; i < layersArray.length; i++){
+        map.addLayer(layersArray[i]);
+      }
+    });          
+  }
+  
   prepareMaps = function(ajaxResponseText){
-    console.log("prepareMaps has been called!");
 
     // FOR ACTION - we will need to change this assignment Of dataset once we start using other datasets.
     dataset = JSON.parse(ajaxResponseText);
     
-    console.log(dataset['features'][0]);
     mapboxSource = prepareSource(dataset, true);
     thisBuildingSource = prepareSource(buildingForPage, false);
     
@@ -126,52 +151,20 @@
         'text-field': "{PROJECT_NAME}",
         'text-anchor': "bottom-left"
       }
-    }
+    };
 
     new MapboxPortal('test-map', [targetBuildingDot, targetBuildingLabel, affordableHousingDots, affordableHousingLabels]);
-  }
-
-  // The MapboxPortal constructor inserts a Mapbox map into element with elementID.
-  // It always adds certain layers (the dot and label for the building-of-interest).
-  // For additional layers, name a function in onloadCAllback. The function will
-  // take the Mapbox map as an argument. 
-  MapboxPortal = function (elementID, layersArray){
-    console.log("There's a new MapboxPortal");
-    console.log("buildingForPage", buildingForPage);
-  // So far the style url and access token come from Paul's Mapbox account.
-  // FOR ACTION - find an accessToken that works for everyone.
-    mapboxgl.accessToken = 'pk.eyJ1IjoicGF1bGdvdHRzY2hsaW5nIiwiYSI6ImNpejF1Y2U3MzA1ZmQzMnA4c3N4a3FkczgifQ.6W04v2jEJFkZvVhOI-yL6A'
-    var map = new mapboxgl.Map({
-      container: elementID,
-      style: 'mapbox://styles/mapbox/streets-v9',
-      center: buildingForPage['geometry']['coordinates'],
-      zoom: 16
-    });
-    
-    // Guidance on adding layers is here: https://www.mapbox.com/mapbox-gl-js/style-spec/#layers
-    // The 'on()' function below appears to be a method of a Mapbox map, though there's no entry
-    // for 'on()' in the Mapbox JS GL API.
-    // Information on styling layers is here:
-    // https://www.mapbox.com/mapbox-gl-js/style-spec/#layer-paint
-    map.on('load', function(){
-      for(var i = 0; i < layersArray.length; i++){
-        map.addLayer(layersArray[i]);
-      }
-    });          
-  }
-    
-   // it looks like grabData isn't being called! 
-   // This might have to do with the mapbox error I'm getting: 't.classList is undefined'
+  };
+  
   (function grabData(callback){
     var req = new XMLHttpRequest();
-    console.log(callback);
-    console.log("grabData is being called!");
     req.open('GET', DATASET_URL);
     req.send();
     req.onreadystatechange = function(){
       if(req.readyState == 4){
-        return callback(req.responseText);
+        return prepareMaps(req.responseText);
       }
     }
-  })(prepareMaps);
+  })();
+
 })();

--- a/javascript/tool/js/building-map.js
+++ b/javascript/tool/js/building-map.js
@@ -10,26 +10,41 @@
       DATASET_URL = "http://opendata.dc.gov/datasets/34ae3d3c9752434a8c03aca5deb550eb_62.geojson",
       // dataset will likely be temporary, given that we will use other datasets!
       dataset,
-      grabData,
       prepareSource,
       prepareMaps,
       thisBuildingSource,
       mapboxSource,
   // NOTE: Until we have a backend that identifies the building a user has chosen to look at
   // (or accomplish this with AJAX), buildingForPage specifies the building that the page is
-  // based around and points to dataset['features'][0];
-      buildingForPage;
+  // based around this object literal, which is taken from the first geoJSON feature
+  // in the Public Housing dataset from Open Data DC. Currently using an object literal because
+  // This information will be available before any AJAX requests to an external data 
+  // source/our own database.
+      buildingForPage = { 
+        "type": "Feature",
+        "properties": { 
+          "OBJECTID":2,
+          "MAR_WARD": "WARD 6",
+          "ADDRESS": "1115 H ST NE, WASHINGTON, DISTRICT OF COLUMBIA 20002",
+          "PROJECT_NAME":"1115 H STREET NE (WOOLWORTH CONDO)",
+          "STATUS_PUBLIC":"COMPLETED 2015 TO DATE",
+          "AGENCY_CALCULATED":"DMPED DHCD",
+          "REPORT_UNITS_AFFORDABLE":"4",
+          "LATITUDE":38.89995096, 
+          "LONGITUDE":-76.99087487,
+          "ADDRESS_ID":311081,
+          "XCOORD":400791.55,
+          "YCOORD":136899.86000000002,
+          "FULLADDRESS":"1115 H STREET NE",
+          "GIS_LAST_MOD_DTTM":
+          "2017-02-27T04:00:37.000Z"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates":[-76.99087714595296,38.89995841328189]
+        }
+      };
   
-  grabData = function(callback){
-    var req = new XMLHttpRequest();
-    req.open('GET', DATASET_URL);
-    req.send();
-    req.onreadystatechange = function(){
-      if(req.readyState == 4){
-        return callback(req.responseText);
-      }
-    }
-  }
   
   // The below function turns a geoJSON object into a source object for Mapbox maps.
   // The second argument determines whether to exclude the building page's target
@@ -56,12 +71,10 @@
   }
   
   prepareMaps = function(ajaxResponseText){
+    console.log("prepareMaps has been called!");
 
     // FOR ACTION - we will need to change this assignment Of dataset once we start using other datasets.
     dataset = JSON.parse(ajaxResponseText);
-    
-    // FOR ACTION - we will need another way to specify the building that is the subject of the building page.
-    buildingForPage = dataset['features'][0];
     
     console.log(dataset['features'][0]);
     mapboxSource = prepareSource(dataset, true);
@@ -100,6 +113,8 @@
   // For additional layers, name a function in onloadCAllback. The function will
   // take the Mapbox map as an argument. 
   MapboxPortal = function (elementID, onloadCallback){
+    console.log("There's a new MapboxPortal");
+    console.log("buildingForPage", buildingForPage);
   // So far the style url and access token come from Paul's Mapbox account.
   // FOR ACTION - find an accessToken that works for everyone.
     mapboxgl.accessToken = 'pk.eyJ1IjoicGF1bGdvdHRzY2hsaW5nIiwiYSI6ImNpejF1Y2U3MzA1ZmQzMnA4c3N4a3FkczgifQ.6W04v2jEJFkZvVhOI-yL6A'
@@ -147,6 +162,18 @@
         
   }
     
-  grabData(prepareMaps);
-  
+   // it looks like grabData isn't being called! 
+   // This might have to do with the mapbox error I'm getting: 't.classList is undefined'
+  (function grabData(callback){
+    var req = new XMLHttpRequest();
+    console.log(callback);
+    console.log("grabData is being called!");
+    req.open('GET', DATASET_URL);
+    req.send();
+    req.onreadystatechange = function(){
+      if(req.readyState == 4){
+        return callback(req.responseText);
+      }
+    }
+  })(prepareMaps);
 })();

--- a/javascript/tool/js/building-map.js
+++ b/javascript/tool/js/building-map.js
@@ -79,40 +79,63 @@
     console.log(dataset['features'][0]);
     mapboxSource = prepareSource(dataset, true);
     thisBuildingSource = prepareSource(buildingForPage, false);
-
     
-    new MapboxPortal('test-map', function(map){
-          
-      map.addLayer({
-        'id': "buildingLocation",
-        'source': mapboxSource,
-        'type': "circle",
-        'minzoom': 11,
-        'paint': {
-          'circle-color': 'rgb(120,150,255)',
-          'circle-stroke-width': 3,
-          'circle-stroke-color': 'rgb(150,150,150)',
-          'circle-radius': 10
-        }
-      });
-      map.addLayer({
-        'id': "buildingTitle",
-        'source': mapboxSource,
-        'type': "symbol",
-        'minzoom': 11,
-        'layout': {
-          'text-field': "{PROJECT_NAME}",
-          'text-anchor': "bottom-left"
-        }
-      });
-    });
+    var targetBuildingDot = {
+      'id': "thisBuildingLocation",
+      'source': thisBuildingSource,
+      'type': 'circle',
+      'minzoom': 11,
+      'paint': {
+        'circle-color': 'red',
+        'circle-stroke-width': 3,
+        'circle-stroke-color': 'red',
+        'circle-radius': 10
+      }
+    };
+    
+    var targetBuildingLabel = {
+      'id': "thisBuildingTitle",
+      'source': thisBuildingSource,
+      'type': "symbol",
+      'minzoom': 11,
+      'layout': {
+        'text-field': "{PROJECT_NAME}",
+        'text-anchor': "bottom-left"
+      }
+    };
+    
+    var affordableHousingDots = {
+			'id': "buildingLocation",
+			'source': mapboxSource,
+			'type': "circle",
+			'minzoom': 11,
+			'paint': {
+				'circle-color': 'rgb(120,150,255)',
+				'circle-stroke-width': 3,
+				'circle-stroke-color': 'rgb(150,150,150)',
+				'circle-radius': 10
+			}
+    };
+    
+    var affordableHousingLabels = {
+      'id': "buildingTitle",
+      'source': mapboxSource,
+      'type': "symbol",
+      'minzoom': 11,
+      'layout': {
+        'text-field': "{PROJECT_NAME}",
+        'text-anchor': "bottom-left"
+      }
+    }
+
+    new MapboxPortal('test-map', [targetBuildingDot, targetBuildingLabel, affordableHousingDots, affordableHousingLabels]);
   }
 
   // The MapboxPortal constructor inserts a Mapbox map into element with elementID.
   // It always adds certain layers (the dot and label for the building-of-interest).
   // For additional layers, name a function in onloadCAllback. The function will
   // take the Mapbox map as an argument. 
-  MapboxPortal = function (elementID, onloadCallback){
+  MapboxPortal = function (elementID, layersArray){
     console.log("There's a new MapboxPortal");
     console.log("buildingForPage", buildingForPage);
   // So far the style url and access token come from Paul's Mapbox account.
@@ -131,35 +154,10 @@
     // Information on styling layers is here:
     // https://www.mapbox.com/mapbox-gl-js/style-spec/#layer-paint
     map.on('load', function(){
-      
-      map.addLayer({
-        'id': "thisBuildingLocation",
-        'source': thisBuildingSource,
-        'type': 'circle',
-        'minzoom': 11,
-        'paint': {
-          'circle-color': 'red',
-          'circle-stroke-width': 3,
-          'circle-stroke-color': 'red',
-          'circle-radius': 10
-        }
-      });
-      
-      map.addLayer({
-        'id': "thisBuildingTitle",
-        'source': thisBuildingSource,
-        'type': "symbol",
-        'minzoom': 11,
-        'layout': {
-          'text-field': "{PROJECT_NAME}",
-          'text-anchor': "bottom-left"
-        }
-      });
-      
-      if(onloadCallback){ onloadCallback(map); }
-      
-    });
-        
+      for(var i = 0; i < layersArray.length; i++){
+        map.addLayer(layersArray[i]);
+      }
+    });          
   }
     
    // it looks like grabData isn't being called! 

--- a/javascript/tool/js/building-map.js
+++ b/javascript/tool/js/building-map.js
@@ -1,3 +1,5 @@
+// FOR ACTION: it doesn't seem like we can use the same source in more than one map on the same page.
+
 (function prepareBuildingMaps(){
   'use strict'
   
@@ -168,7 +170,7 @@
 			'type': "circle",
 			'minzoom': 11,
 			'paint': {
-				'circle-color': 'rgb(120,150,255)',
+				'circle-color': 'white',
 				'circle-stroke-width': 3,
 				'circle-stroke-color': 'green',
 				'circle-radius': 5

--- a/javascript/tool/js/building-map.js
+++ b/javascript/tool/js/building-map.js
@@ -1,16 +1,3 @@
-// NOW FIXING THIS ISSUE: datasets['affordableHousing']['data'] is never assigned, even
-// when it should be! After both AJAX requests are completed, datasets['metroStations']['data']
-// exists, but not datasets['affordableHousing']['data'].
-// - The program iterates through only the expected keys in dataset when producing
-//   XHR requests.
-// - If I log the ready state of each object in the 'ajaxRequests' dictionary, only
-//   metroStations gives any updates.
-// - However, the value of each key in ajaxRequests, the XHR object, has the expected
-//   responseText.
-// - At the same time, if you log 'dataset', only one key has a 'data' object as part of 
-//  its value, 'metroStations', the only key providing updates.
-
-
 (function prepareBuildingMaps(){
   'use strict'
   
@@ -59,13 +46,12 @@
       
       // incorporate this with the 'app' object later. This will likely involve a different approach.
       datasets = {
-        affordableHousing: {
-          url: "http://opendata.dc.gov/datasets/34ae3d3c9752434a8c03aca5deb550eb_62.geojson"
-        },
         metroStations: {
           url: "http://opendata.dc.gov/datasets/54018b7f06b943f2af278bbe415df1de_52.geojson"
-        }
-        
+        },
+        affordableHousing: {
+          url: "http://opendata.dc.gov/datasets/34ae3d3c9752434a8c03aca5deb550eb_62.geojson"
+        }        
       }
   
   
@@ -127,9 +113,7 @@
       thisBuildingSource: prepareSource(buildingForPage, false),
       metroStations: prepareSource(datasets['metroStations']['data'], false)
     };
-    
-    console.log('sources near the top of prepareMaps', sources);
-    
+        
     var targetBuildingDot = {
       'id': "thisBuildingLocation",
       'source': sources['thisBuildingSource'],
@@ -166,10 +150,7 @@
 				'circle-radius': 10
 			}
     };
-    
-    console.log('thisBuildingSource', sources['thisBuildingSource']);
-    console.log('publicHousingSource', sources['publicHousingSource']);
-    
+        
     var affordableHousingLabels = {
       'id': "buildingTitle",
       'source': sources['publicHousingSource'],
@@ -206,10 +187,8 @@
     };
 
     new MapboxPortal('affordable-housing-map', [targetBuildingDot, targetBuildingLabel, affordableHousingDots, affordableHousingLabels]);
-    console.log("After the first call to new MapboxPortal");
     
-//     new MapboxPortal('metro-stations-map', [targetBuildingDot, targetBuildingLabel, metroStationDots, metroStationLabels]);
-    console.log("After the second call to new MapboxPortal");
+    new MapboxPortal('metro-stations-map', [targetBuildingDot, targetBuildingLabel, metroStationDots, metroStationLabels]);
   };
   
   (function grabData(){
@@ -222,12 +201,14 @@
       var completedRequests = Object.keys(ajaxRequests).filter(function(key){
         return ajaxRequests[key].readyState == 4;
       });
-      
-      console.log("ajaxRequests", ajaxRequests);
+            
       if(completedRequests.length == Object.keys(ajaxRequests).length){
         clearInterval(checkRequestsInterval);
-        console.log("I should be preparing the maps now");
-        console.log('datasets after all requests completed', datasets);
+        
+        for(var i in ajaxRequests){
+          var response = ajaxRequests[i].responseText;
+          datasets[i].data = JSON.parse(response);
+        }
         prepareMaps();
       }
       currentInterval = 0;
@@ -239,14 +220,6 @@
       ajaxRequests[i] = new XMLHttpRequest();
       ajaxRequests[i].open('GET', datasets[i]['url']);
       ajaxRequests[i].send();
-      ajaxRequests[i].onreadystatechange = function(){
-        console.log("Ready state for " + i, ajaxRequests[i].readyState);
-        if(ajaxRequests[i].readyState == 4){
-          var response = ajaxRequests[i].responseText;
-          console.log('ajaxRequests[i].responseText:', ajaxRequests[i].responseText);
-          datasets[i].data = JSON.parse(response);
-        }
-      }
     }
     checkRequestsInterval = setInterval(checkRequests, 500);
 


### PR DESCRIPTION
@NealHumphrey @vincecampanale @wassona @ostermanj 
I've added a grabData() function that requests geoJSON from data sources specified in a 'datasets' object literal. A setInterval() function waits for all responses to come back, then assigns the geoJSON to the 'data' keys in the 'datasets' object, and calls a prepareMaps() function that produces the Mapbox maps.

Doing this created issues with scope in defining layers in the MapboxPortal constructor, so I've moved all layer definitions to prepareMaps(). Now MapboxPortal simply iterates over all the layer IDs passed to an argument as an array of strings.

I've also added a 'buildingForPage' object literal as a placeholder for whatever way we decide on to bind data about a selected building to the information page.

At the moment, there is an error in loading the maps. As far as I understand it, this is because Mapbox maps can't include a source with the same ID multiple times.

I wanted to issue a pull request to keep you all up to speed on what I'm doing, but I can work on fixing the error before we merge if that's what you'd prefer.