### PR TITLE
On the building page, list nearby features

### DIFF
--- a/javascript/tool/building.html
+++ b/javascript/tool/building.html
@@ -104,8 +104,7 @@
 						<div class="col-sm-6">
 							<div class="mapbox-portal" id="affordable-housing-map"></div>
 						</div>
-						<div class="col-sm-6">
-							Here's some test text.
+						<div class="col-sm-6" id = "nearbyAffordableHousing">
 						</div>
 					</div>
 				</div>
@@ -125,8 +124,7 @@
 						<div class="col-sm-6">
 							<div class="mapbox-portal" id="metro-stations-map"></div>
 						</div>
-						<div class="col-sm-6">
-							Here's some test text.
+						<div class="col-sm-6" id = "nearbyMetroStations">
 						</div>
 					</div>
 				</div>
@@ -135,6 +133,8 @@
 	</section><!-- page-specific asset calls that require ready DOM elements -->
 	<script src="js/building-chart.js">
 	</script> 
+  <script src="js/geo-distance.js">
+	</script>
 	<script src="js/building-map.js">
 	</script> 
 	<script src="js/building-header.js">

--- a/javascript/tool/js/geo-distance.js
+++ b/javascript/tool/js/geo-distance.js
@@ -1,0 +1,67 @@
+// This code has been copied piecemeal from the following source:
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  */
+/* Latitude/longitude spherical geodesy tools                         (c) Chris Veness 2002-2016  */
+/*                                                                                   MIT Licence  */
+/* www.movable-type.co.uk/scripts/latlong.html                                                    */
+/* www.movable-type.co.uk/scripts/geodesy/docs/module-latlon-spherical.html                       */
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  */
+
+/** Extend Number object with method to convert numeric degrees to radians */
+if (Number.prototype.toRadians === undefined) {
+    Number.prototype.toRadians = function() { return this * Math.PI / 180; };
+}
+
+/** Extend Number object with method to convert radians to numeric (signed) degrees */
+if (Number.prototype.toDegrees === undefined) {
+    Number.prototype.toDegrees = function() { return this * 180 / Math.PI; };
+}
+
+/**
+ * Creates a LatLon point on the earth's surface at the specified latitude / longitude.
+ *
+ * @constructor
+ * @param {number} lat - Latitude in degrees.
+ * @param {number} lon - Longitude in degrees.
+ *
+ * @example
+ *     var p1 = new LatLon(52.205, 0.119);
+ */
+function LatLon(lat, lon) {
+    // allow instantiation without 'new'
+    if (!(this instanceof LatLon)) return new LatLon(lat, lon);
+
+    this.lat = Number(lat);
+    this.lon = Number(lon);
+}
+
+/**
+ * Returns the distance from ‘this’ point to destination point (using haversine formula).
+ *
+ * @param   {LatLon} point - Latitude/longitude of destination point.
+ * @param   {number} [radius=6371e3] - (Mean) radius of earth (defaults to radius in metres).
+ * @returns {number} Distance between this point and destination point, in same units as radius.
+ *
+ * @example
+ *     var p1 = new LatLon(52.205, 0.119);
+ *     var p2 = new LatLon(48.857, 2.351);
+ *     var d = p1.distanceTo(p2); // 404.3 km
+ */
+LatLon.prototype.distanceTo = function(point, radius) {
+    if (!(point instanceof LatLon)) throw new TypeError('point is not LatLon object');
+    radius = (radius === undefined) ? 6371e3 : Number(radius);
+
+    var R = radius;
+    var φ1 = this.lat.toRadians(),  λ1 = this.lon.toRadians();
+    var φ2 = point.lat.toRadians(), λ2 = point.lon.toRadians();
+    var Δφ = φ2 - φ1;
+    var Δλ = λ2 - λ1;
+
+    var a = Math.sin(Δφ/2) * Math.sin(Δφ/2)
+          + Math.cos(φ1) * Math.cos(φ2)
+          * Math.sin(Δλ/2) * Math.sin(Δλ/2);
+    var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+    var d = R * c;
+
+    return d;
+};
+


### PR DESCRIPTION
#80 
@ostermanj @wassona @vincecampanale 

Since the text of the map-related accordion panels in the building page prototype has to do with features near the target building, I've copied some code from a library for geospatial calculations to assign distances to a given Mapbox source and list those distances next to the relevant map.

A big difference from the prototype is that this code calculates geospatial distance to nearby metro stations, whereas the prototype shows walking distance. While the calculations of geospatial distance use snippets of a JS library copied to a file in the 'js' folder, I imagine calculating walking distance will involve some asynchronous API calls to, say, Google Maps. This can be something to look into later!