### PR TITLE
updating env yml for mac

### DIFF
--- a/python/environment.yml
+++ b/python/environment.yml
@@ -2,21 +2,19 @@ name: housing-insights
 channels:
 - defaults
 dependencies:
-- libpq=9.5.4=vc14_0
-- mkl=11.3.3=1
+- libpq=9.5.4
+- mkl=11.3.3
 - numpy=1.11.2=py35_0
-- openssl=1.0.2j=vc14_0
+- openssl=1.0.2j
 - pandas=0.19.0=np111py35_0
 - pip=8.1.2=py35_0
 - psycopg2=2.6.2=py35_0
 - python=3.5.2=0
 - python-dateutil=2.5.3=py35_0
 - pytz=2016.7=py35_0
-- setuptools=27.2.0=py35_1
+- setuptools=27.2.0
 - six=1.10.0=py35_0
 - sqlalchemy=1.1.3=py35_0
-- vc=14=0
-- vs2015_runtime=14.0.25123=0
 - wheel=0.29.0=py35_0
 - pip:
   - awscli==1.11.66


### PR DESCRIPTION
Removed the last bits of the versions for things that were not in the osx64 channel.

I also had to remove vc & vs2015 entirely since no versions are in the osx64 channel at all.  I was able to run the load_data script without them so hopefully they aren't necessary...
@NealHumphrey 