### PR TITLE
Fixes encoding issue on Mac,

### DIFF
--- a/python/housinginsights/ingestion/DataReader.py
+++ b/python/housinginsights/ingestion/DataReader.py
@@ -37,7 +37,7 @@ class HIReader(object):
         self._counter = Counter()
 
         if self.path_type == "file":
-            with open(self.path, 'r', newline='') as data:
+            with open(self.path, 'r', newline='', encoding='latin-1') as data:
                 reader = DictReader(data)
                 self._keys = reader.fieldnames
                 for row in reader:


### PR DESCRIPTION
 though doesn't address the root cause that different files can have different encoding. See issue #169 for next steps.

@prisalex and @louvis  and @emkap01  and anyone else that has a Mac, this should fix the problem of not being able to build the Docker database. Let me know if it doesn't!