### PR TITLE
Fix docker-compose race condition Fixes #173

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
             - postgres
         ports:
             - "8081:8081"
-      
+        restart: "on-failure:10"
+
     postgres:
         image: codefordc2/housing-insights-postgres
         environment:
@@ -27,3 +28,4 @@ services:
             - POSTGRES_DB=housinginsights_docker
         ports:
             - "5432:5432"
+        restart: "on-failure:3"


### PR DESCRIPTION
Fixes the docker-compose race condition by re-trying in the event of a failure.  However, the retries are bounded (10 for web, 3 for postgres) so that if there is an actual problem with a configuration, it will still fail as expected, rather than retrying infinitely.