### PR TITLE
Create promise for map load to ensure app init function will always b…

### DIFF
--- a/javascript/tool/js/rich-map.js
+++ b/javascript/tool/js/rich-map.js
@@ -9,9 +9,13 @@ var map = new mapboxgl.Map({
   preserveDrawingBuffer: true
 });
 
+var map_loaded = new Promise(function(resolve, reject){
+  map.on('load', resolve);
+});
+
 function prepareMaps(){
 
-  map.on('load', function() {
+  map_loaded.then(function() {
 
     map.addSource("zip", {
       "type": "geojson",


### PR DESCRIPTION
…e called.

Basically what this commit does is it creates a promise that will resolve when the map loads.  When you attach a callback to a promise via .then it will do one of two things.  If the promise has already been resolved it will run the registered function immediately.  Otherwise it will wait until the promise resolves, then call the function.