### PR TITLE
Fix issue 206 using promises

### DIFF
--- a/javascript/tool/js/rich-map.js
+++ b/javascript/tool/js/rich-map.js
@@ -9,9 +9,13 @@ var map = new mapboxgl.Map({
   preserveDrawingBuffer: true
 });
 
+var map_loaded = new Promise(function(resolve, reject){
+  map.on('load', resolve);
+});
+
 function prepareMaps(){
 
-  map.on('load', function() {
+  map_loaded.then(function() {
 
     map.addSource("zip", {
       "type": "geojson",


### PR DESCRIPTION
Basically what is happening is a promise is being created that "resolves" when the map is successfully loaded.  When you register a callback on a promise (via .then), either the callback will be run right away if the promise has already resolved, or it will wait for the promise is resolved, then run the callback.  This is helpful because we don't know whether the map load or the data API call with finish first.