### PR TITLE
Add permits and projects w/in distance

### DIFF
--- a/python/api/requirements.txt
+++ b/python/api/requirements.txt
@@ -7,3 +7,4 @@ MarkupSafe==1.0
 psycopg2==2.7.1
 SQLAlchemy==1.1.9
 Werkzeug==0.12.1
+simplejson==3.10.0

--- a/python/scripts/meta.json
+++ b/python/scripts/meta.json
@@ -890,14 +890,14 @@
                 "display_text": "",
                 "source_name": "Proj_Units_Assist_Min",
                 "sql_name": "proj_units_assist_min",
-                "type": "text"
+                "type": "integer"
             },
             {
                 "display_name": "proj_units_assist_max",
                 "display_text": "",
                 "source_name": "Proj_Units_Assist_Max",
                 "sql_name": "proj_units_assist_max",
-                "type": "text"
+                "type": "integer"
             },
             {
                 "display_name": "hud_own_effect_dt",


### PR DESCRIPTION
Adds two endpoints to the API, one for nearby_projects and one for nearby_building_permits that use a lat/lon param to calculate the building permits within X miles. 

This also implements a couple changes to how jsonify writes json, to resolve some issues related to data types that this endpoint highlighted. 

This is deployed to the live site

TODO in a refactor we'll want to eliminate duplicative code