### PR TITLE
Add a new directory for high-level refactoring options and discussion

### DIFF
--- a/javascript/refactoring_sandboxes/option1/chart_types.js
+++ b/javascript/refactoring_sandboxes/option1/chart_types.js
@@ -1,0 +1,24 @@
+// PG: It would be nice to reduce the number of arguments to something easier to
+// memorize. 
+// We still have to incorporate Bostock's guidance re: reusable charts.
+// We also have to work out how to integrate this with DataObject (see data_objects.js).
+var Chart = function(DATA_FILE, el, field, sortField, asc, readableField) {};
+
+Chart.prototype = {
+  data: [],
+    
+  initialize: function(DATA_FILE, el, field, sortField, asc, readableField) {},
+  initialSetup: function(DATA_FILE,el,field,sortField,asc, readableField){
+    this.data; 
+    this.minValue;
+    this.maxValue;
+  },
+
+  legend: function(){ //returns an HTMLElement object and its children}
+}; 
+
+// Code for defining PieCharts and inheriting from Chart from pie.js.
+var PieChart = function(DATA_FILE, dataName, el, field, width, height) {};
+
+// Code for defining SubsidtyTimelineCharts and inheriting from Chart from subsidy-timeline.js.
+var SubsidyTimelineChart = function(DATA_FILE, dataName, el, field, sortField, asc, readableField, width, height, building) {};

--- a/javascript/refactoring_sandboxes/option1/data_objects.js
+++ b/javascript/refactoring_sandboxes/option1/data_objects.js
@@ -1,0 +1,21 @@
+var allDataObjects = [];
+
+function DataObject(tableName, queryModifiers){
+  allDataObjects.push(this);
+  // fetches data from the API unless already loaded.
+  // 'tableName' is a string taken from meta.json.
+  // queryModifiers is an object litera. These wouldn't
+  // be SQL queries but rather options for the API call. E.g. the constructor call
+  // be, 'new DataObject('project', { 'zone' : 'ward' }
+
+  // We still need to work out how to represent the process of grabbing data
+  // from other data objects. This could be a method ('getFrom(dataObject)', or
+  // it could be a property of the queryModifiers object. We could have the constructor
+  // look for any necessary data within existing dataObjects first.)
+
+  this.data; //returns the data
+
+}
+
+  // The assumption is that we'll create DataObject instances within the view-specific
+  // .js files.

--- a/javascript/refactoring_sandboxes/option1/user_selection_components.js
+++ b/javascript/refactoring_sandboxes/option1/user_selection_components.js
@@ -1,0 +1,10 @@
+// attributesObj includes the key 'chart
+function UserSelectionComponent(attributesObj){
+  this.makePublic = function() {
+    PubSub.publish("message!", { }, false, false);
+  } 
+}
+
+// One possibility: individual views include UserSelectionComponents by invoking the
+// constructor. Since this wouldn't be a single page app, the USCs wouldn't exist across
+// multiple pages unless constructed anew.

--- a/javascript/refactoring_sandboxes/option1/views/building_view.js
+++ b/javascript/refactoring_sandboxes/option1/views/building_view.js
@@ -1,0 +1,9 @@
+(function makeAccordion(){
+
+// code from accordion.js
+
+}())
+
+// code from building-header.js (except DataOnly)
+
+// code from building-map.js

--- a/javascript/refactoring_sandboxes/option1/views/map_view.js
+++ b/javascript/refactoring_sandboxes/option1/views/map_view.js
@@ -1,0 +1,54 @@
+var prepareBuildingMaps = function(buildingLat,buildingLon){
+  'use strict'
+  
+  var buildingID;
+
+  var datasets,
+      prepareSource,
+      prepareMaps,
+      addCurrentBuilding,
+      addRoutes,
+      prepareSidebar,
+      thisBuildingSource,
+      ProtoLayer,
+      mapboxSource,
+      buildingForPage,      
+
+      datasets = {};
+  
+  mapboxgl.accessToken;
+
+  prepareMaps = function(){      
+    var affordableHousingMap;
+    // add affordableHousingMap sources and layers.
+    
+    var metroStationsMap; 
+    // add metroStationsMap sources and layers.                      
+  };
+
+  //Adds single building icon and label. Encourages consistent formatting of the selected building
+  addCurrentBuilding = function(map,source){};
+  
+  prepareSidebar = function(){
+    
+    ///////////////////
+    //Transit sidebar
+    ///////////////////
+    var numBusRoutes;
+    var numRailRoutes; 
+
+    //TODO this is a pretty hacky way to do this but it lets us use the same specs as above
+    //TODO should make this approach to a legend a reusable method if desired, and then
+    //link the values here to the relevant attributes in the addLayer method.
+    var rail_icon;
+    var brgSorted;
+    var rrgSorted;
+
+  };
+
+  addRoutes = function(id,data){};
+
+// Why don't we replace the 'grabData' function at the bottom of building-map.js with
+// a 'grab' method (or similar) of the DataObj constructor (in data_object.js of option1)?
+
+};

--- a/javascript/refactoring_sandboxes/original_structure/PubSub.js
+++ b/javascript/refactoring_sandboxes/original_structure/PubSub.js
@@ -1,0 +1,1 @@
+// No changes to PubSub.js in this option, as this is an external module.

--- a/javascript/refactoring_sandboxes/original_structure/accordion.js
+++ b/javascript/refactoring_sandboxes/original_structure/accordion.js
@@ -1,0 +1,27 @@
+(function(){
+
+	var expandCounter,
+		expandArray,
+		collapseArray,
+		expandAllObject,
+		collapseAllObject;
+
+	document.querySelectorAll('.down-arrow-button').forEach(function(element){
+		element.addEventListener('click', expand);
+	});
+
+	document.querySelector('.accordion-collapser').addEventListener('click', expandAll);
+
+	function expand(e, element){};
+
+	function collapse(e, element){};
+
+	function accordion(e, element, object){};
+
+	function expandAll(e, element){};
+
+	function collapseAll(e, element){};
+
+	function accordionAll(e, element, object){};
+
+}())

--- a/javascript/refactoring_sandboxes/original_structure/building-chart.js
+++ b/javascript/refactoring_sandboxes/original_structure/building-chart.js
@@ -1,0 +1,1 @@
+// building-chart.js is not used in this refactoring option.

--- a/javascript/refactoring_sandboxes/original_structure/building-header.js
+++ b/javascript/refactoring_sandboxes/original_structure/building-header.js
@@ -1,0 +1,10 @@
+
+
+var buildingID;
+
+var DATA_FILE;
+
+var DataOnly = function(DATA_FILE){};
+DataOnly.prototype = Object.create(Chart.prototype); 
+
+new DataOnly(DATA_FILE);

--- a/javascript/refactoring_sandboxes/original_structure/building-map.js
+++ b/javascript/refactoring_sandboxes/original_structure/building-map.js
@@ -1,0 +1,60 @@
+var prepareBuildingMaps = function(buildingLat,buildingLon){
+  'use strict'
+  
+  var buildingID;
+
+  var datasets,
+      prepareSource,
+      prepareMaps,
+      addCurrentBuilding,
+      addRoutes,
+      prepareSidebar,
+      thisBuildingSource,
+      ProtoLayer,
+      mapboxSource,
+      buildingForPage,      
+
+      datasets = {};
+  
+  mapboxgl.accessToken;
+
+  prepareMaps = function(){      
+    var affordableHousingMap;
+    // add affordableHousingMap sources and layers.
+    
+    var metroStationsMap; 
+    // add metroStationsMap sources and layers.                      
+  };
+
+  //Adds single building icon and label. Encourages consistent formatting of the selected building
+  addCurrentBuilding = function(map,source){};
+  
+  prepareSidebar = function(){
+    
+    ///////////////////
+    //Transit sidebar
+    ///////////////////
+    var numBusRoutes;
+    var numRailRoutes; 
+
+    //TODO this is a pretty hacky way to do this but it lets us use the same specs as above
+    //TODO should make this approach to a legend a reusable method if desired, and then
+    //link the values here to the relevant attributes in the addLayer method.
+    var rail_icon;
+    var brgSorted;
+    var rrgSorted;
+
+  };
+
+  addRoutes = function(id,data){};
+
+  (function grabData(){
+    var ajaxRequests;
+    var maxIntervals;
+    var currentInterval;
+    var checkRequestsInterval;
+    
+    function checkRequests(){};
+  })();
+
+};

--- a/javascript/refactoring_sandboxes/original_structure/d3-tip.js
+++ b/javascript/refactoring_sandboxes/original_structure/d3-tip.js
@@ -1,0 +1,1 @@
+// No changes to d3-tip.js in this option, as this is an external module.

--- a/javascript/refactoring_sandboxes/original_structure/geo-distance.js
+++ b/javascript/refactoring_sandboxes/original_structure/geo-distance.js
@@ -1,0 +1,1 @@
+// geo-distance.js is not used in this refactoring option.

--- a/javascript/refactoring_sandboxes/original_structure/housing-insights.js
+++ b/javascript/refactoring_sandboxes/original_structure/housing-insights.js
@@ -1,0 +1,50 @@
+'use strict';
+
+String.prototype.hashCode = function(){};
+
+String.prototype.capitalizeFirstLetter = function(){};
+function APIDataObj(json){
+  this.json = json;
+  this.toGeoJSON = function(longitudeField, latitudeField){
+    var features;
+  }
+}
+
+function addDataToPolygons(geoJSONPolygons, aggregateData, zoneNamesMatch){};
+
+var app = {
+  dataCollection: {}, 
+  getInitialData: function(urlsObjArray, doAfter){
+    var MAX_INTERVALS,
+        ajaxRequests,
+        currentInterval,
+        checkRequestsInterval,
+        REQUEST_TIME,
+        _this;
+              
+    function checkRequests(){
+      var completedRequests;
+    }
+  },
+  
+  getData: function(DATA_FILE, el, field, sortField, asc, readableField, chart){
+    var dataName;
+  },
+
+  getParameterByName: function(name, url){}
+};
+              
+var Chart = function(DATA_FILE, el, field, sortField, asc, readableField) {};
+
+Chart.prototype = {
+  data: [],
+    
+  initialize: function(DATA_FILE, el, field, sortField, asc, readableField) {},
+  initialSetup: function(DATA_FILE,el,field,sortField,asc, readableField){
+    this.data; 
+    this.minValue;
+    this.maxValue;
+  },
+                      
+  extendPrototype: function(destinationPrototype, obj){ } 
+}; 

--- a/javascript/refactoring_sandboxes/original_structure/moving-blocks.js
+++ b/javascript/refactoring_sandboxes/original_structure/moving-blocks.js
@@ -1,0 +1,1 @@
+// This option does not include moving-block.js.

--- a/javascript/refactoring_sandboxes/original_structure/pie.js
+++ b/javascript/refactoring_sandboxes/original_structure/pie.js
@@ -1,0 +1,53 @@
+"use strict";
+
+Array.prototype.move = function (old_index, new_index) {};
+ 
+ var mapZones = {};
+
+var readable = {};
+
+var currentZoneType;
+
+
+var PieChart = function(DATA_FILE, dataName, el, field, width, height) {};
+PieChart.prototype = Object.create(Chart.prototype);
+
+var PieExtension = { 
+  returnPieVariable: function(field,zoneType,zoneName) {
+    
+    this.nested;
+
+    var allObject = { };
+    var stagePieVariable;
+  },
+  addPercentYes: function(stagePieVariable){ },
+  checkForEmpties: function(){},  
+  setup: function(el, field, width, height){
+    this.field;
+    this.width;
+    this.height;
+    var chart;
+    this.pieVariable;
+    
+    chart.radius;
+    chart.svg;
+    chart.arc;
+    chart.background;
+    chart.foreground;
+    chart.percentage;
+    chart.label;
+  },
+  arcTween: function(newAngle) { },
+  returnTextPercent: function(){},
+  update: function(){}
+};
+
+
+var DATA_FILE;
+
+
+function changeZoneType() {};
+
+function changeZone(e) {};
+
+function setOptions(nested) {}

--- a/javascript/refactoring_sandboxes/original_structure/rich-map.js
+++ b/javascript/refactoring_sandboxes/original_structure/rich-map.js
@@ -1,0 +1,80 @@
+mapboxgl.accessToken;
+
+var map;
+
+function prepareMaps(){
+
+  app.dataCollection.neighborhood_data_polygons;
+
+  app.dataCollection.ward_data_polygons;
+
+  function mapLoadedCallback() {
+
+    // Add sources and layers
+  
+    var categoryLegendEl;
+	
+    var toggleableLayerIds;
+
+    map.clickedLayer;
+    var previousLayer;
+
+    var dataSourceIds;
+    var dataSourcesByLayer;
+    var selectedDataLayer;
+
+    function showLayer() {};
+
+    function showDataLayer(dataSourceId){};
+
+    function hideDataLayer(){};
+
+    function updateDataSourceMenu() {};
+
+    function titleString(string) {
+      function capFirst(string){
+      }
+    }
+
+    for (var i = 0; i < toggleableLayerIds.length; i++) {
+      var id = toggleableLayerIds[i];
+
+      var link = document.createElement('a');
+      link.href = '#';
+      link.textContent = titleString(id);
+      link.dataset.id = id;
+
+      link.onclick = function (e) {
+        map.clickedLayer = this.dataset.id;
+        e.preventDefault();
+        e.stopPropagation();
+        showLayer.call(this); // call reusable function with current `this` (element) as context -JO
+        setHeader();
+        changeZoneType(); // defined in pie.js
+        updateDataSourceMenu();
+      };
+
+      var layers = document.getElementById('menu');
+      layers.appendChild(link);
+    }
+
+    showLayer.call(document.querySelector('nav#menu a:first-of-type')); // this call happens once on load, sets up initial
+                                                                     // condition of having first option active.
+
+    // Produce the data sources menu
+
+    // Set up the sidebar and header
+      var popup;
+
+    // Note: There is a lot of code here that's been deleted in this exercise, code that
+    // hasn't been separated into functions/objects/variables.
+                                                        
+    map.pieCharts = [];
+  }
+}
+
+function setHeader(){}
+
+// The line below isn't a function/var/obj declaration, but I'm leaving it here because it contains
+// a sizeable chunk of code in the arguments.
+app.getInitialData();

--- a/javascript/refactoring_sandboxes/original_structure/subsidy-timeline.js
+++ b/javascript/refactoring_sandboxes/original_structure/subsidy-timeline.js
@@ -1,0 +1,31 @@
+"use strict"; 
+
+var SubsidyTimelineChart = function(DATA_FILE, dataName, el, field, sortField, asc, readableField, width, height, building) {};
+SubsidyTimelineChart.prototype = Object.create(Chart.prototype);
+
+var subsidyTimelineExtension = { // Final step of inheriting from Chart, defines the object with which to extend the prototype
+                             // as called in this.extendPrototype(...) above 
+  setup: function(dataName, el, field, sortField, asc, readableField) {
+    chart.svg;
+    chart.minTime;
+    chart.maxTime;
+    chart.xScale;
+    chart.yScale = function(i){};
+    
+    // 'append' calls to add text, lines and decorations to the chart
+  }, 
+
+  timeParser: {   
+    month: function(string) { },
+    day: function(string){ },
+    year: function(string){ },
+    toUTC: function(string){ },
+    parsedDate: function(string){ }
+  }
+
+};
+
+var DATA_FILE = './data/Subsidy.csv';
+
+new SubsidyTimelineChart(DATA_FILE,'projectCSV','#subsidy-timeline-chart','Proj_Units_Tot','Proj_Zip',false,'Total Units',1000,300,buildingID); 
+


### PR DESCRIPTION
#212 
I've also begun (like, super-preliminarily) to translate the whiteboard sketch into constructor declarations and .js files within the 'javascript/refactoring_sandboxes/option1' directory. 'javascript/refactoring_sandboxes/original_structure' takes you to a version of the dev branch's 'javascript/tool/js' directory in which everything but the main constructor, function and variable declarations have been taken out.

Let me know what's useful or not here and I can keep plugging away at it. 

I see this as more of a communication tool than an actual version of the code. For alternative structures, we could add other 'option' directories. It's less efficient than using git branches but lets you have the same file from each variation open in your editor.