### PR TITLE
Fix double declaration of psycopg2 in requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -16,4 +16,3 @@ s3transfer==0.1.10
 six==1.10.0
 SQLAlchemy==1.1.3
 flask
-psycopg2


### PR DESCRIPTION
When attempting to build the necessary Python harness virtualenv environment on a recently updated copy of ArchLinux using Python 3.6, I encounter the following error.

`Double requirement given: psycopg2 (from -r requirements.txt (line 19)) (already in psycopg2==2.6.2 (from -r requirements.txt (line 8)), name='psycopg2')`

This removes the extraneous, double declaration of the psycopg2 adapter, favoring the general one for the pegged version one. I was then successfully able to build the virtual environment as needed.

Reviewing tickets currently open makes it seem this might be generally know to be an issue associated with Docker and deployment, for instance mentioned in #154.