### PR TITLE
133 bom removal in opendata dc gov file headers

### DIFF
--- a/python/housinginsights/ingestion/Cleaners.py
+++ b/python/housinginsights/ingestion/Cleaners.py
@@ -456,6 +456,17 @@ class CrimeCleaner(CleanerBase):
         return row
 
 
+class DCTaxCleaner(CleanerBase):
+    def clean(self, row, row_num = None):
+        row = self.replace_nulls(row, null_values=['', '\\', None])
+        row['OWNER_ADDRESS_CITYSTZIP'] = self.null_value                            \
+                                            if row['OWNER_ADDRESS_CITYSTZIP']==','  \
+                                            else row['OWNER_ADDRESS_CITYSTZIP']
+        row['VACANT_USE'] = self.convert_boolean(row['VACANT_USE'].capitalize())
+        row = self.parse_dates(row)
+        return row
+
+
 class hmda_cleaner(CleanerBase):    
     def clean(self, row, row_num = None):
         row = self.replace_nulls(row, null_values=['', None])

--- a/python/housinginsights/ingestion/DataReader.py
+++ b/python/housinginsights/ingestion/DataReader.py
@@ -8,10 +8,13 @@ import csv
 from os import path
 import os
 
-import logging
+import sys, logging, traceback
 
-from urllib.request import urlretrieve
-from urllib.request import urlopen
+from http.client import HTTPConnection, HTTPSConnection, HTTPResponse, HTTPException, OK
+from urllib.parse import urlparse
+from urllib.request import urlopen, urlretrieve
+from urllib.error import URLError
+
 import codecs
 
 from datetime import datetime
@@ -32,10 +35,10 @@ class HIReader(object):
     Note, local files are preferred when possible for faster processing time
     and lower bandwidth usage.
     """
-    def __init__(self, path, path_type="file", encoding="latin-1"):
+    def __init__(self, path, path_type="file", encoding="latin-1", keys=None):
         self.path = path
         self._length = None
-        self._keys = None
+        self._keys = keys
         self.path_type = path_type
         self.encoding = encoding
 
@@ -101,7 +104,7 @@ class HIReader(object):
 class ManifestReader(HIReader):
     """
     Adds extra functions specific to manifest.csv. This is the class that
-    should be used to read the manifest and return it row-by-row. 
+    should be used to read the manifest and return it row-by-row.
     """
 
     _include_flags_positive = ['use']
@@ -127,7 +130,7 @@ class ManifestReader(HIReader):
                     row['data_date'] = datetime.strftime(_date, '%Y-%m-%d')
                 except ValueError:
                     row['data_date'] = 'Null'
-                
+
                 #return the row
                 yield row
 
@@ -192,33 +195,127 @@ class DataReader(HIReader):
         self.manifest_row = manifest_row
         self.destination_table = manifest_row['destination_table']
 
-        # use default encoding if none found
+        # Use default encoding if none found
         if 'encoding' not in manifest_row:
-            logging.warning("  Warning: encoding not found in manifest. "
+            logging.warning("  Warning: encoding not found in manifest. " \
                             "Falling back to latin-1.")
         self.encoding = manifest_row.get('encoding', 'latin-1')
 
         self.load_from = load_from
-        self.s3_path = os.path.join(manifest_row['s3_folder'],
-                                    manifest_row['filepath'].strip(
-                                        "\/")).replace("\\","/")
+        self.s3_path = os.path.join( manifest_row['s3_folder'],
+                                     manifest_row['filepath'].strip("\/")
+                                        ).replace("\\","/")
+        self._error_reporting_overhead = {}
+        # Test connection to s3 URL
+        if self.manifest_row['include_flag'] == 'use':
+            self._suppress_verbose_error_reporting()
+            content_type_header = self._test_connection_to_URL(self.s3_path)
+            self._restore_verbose_error_reporting()
+            if content_type_header is not None:
+                logging.info("  Content (MIME) type: {}".format(content_type_header))
 
-        # load data file from given file system - S3 or local
+        self._keys = None
+        # Load data file from given file system - S3 or local
         if load_from == "s3":
             self.path = self.s3_path
             self.path_type = "url"
         else:
-            self.path = os.path.join(path.dirname(__file__),
-                                     manifest_row['local_folder'],
-                                     manifest_row['filepath'].strip("\/"))
+            self.path = os.path.normpath(
+                            os.path.join(path.dirname(__file__),
+                                         manifest_row['local_folder'],
+                                         manifest_row['filepath']))
             self.path_type = "file"
 
             if self.manifest_row['include_flag'] == 'use':
-                self._download_data_file()
+                headers = self._download_data_file()
+
+        self._keys = self._set_keys()
 
         self.not_found = [] #Used to log missing fields compared to meta data
 
-        super().__init__(self.path, self.path_type, self.encoding)
+        super().__init__(self.path, self.path_type, self.encoding, self._keys)
+
+    def __iter__(self):
+        """
+        Iterator wrapper that only uses canonical header fieldname keys
+        provided by _set_keys().
+        (Note: These canonical keys differ from those yielded by DictReader's
+               fieldnames property whenever the header row contains a BOM.)
+        """
+        self._length = 0
+        self._counter = Counter()
+
+        if self.path_type == "file":
+            with open(self.path, 'r', newline='',
+                      encoding=self.encoding) as data:
+                # Always use canonical header fieldname keys:
+                reader = DictReader(data, fieldnames=self._keys)
+                header = next(reader)   # Omit header row from output
+                for row in reader:
+                    self._length += 1
+                    yield row
+
+        elif self.path_type == "url":
+            with urlopen(self.path) as ftpstream:
+                # Always use canonical header fieldname keys:
+                reader = DictReader(codecs.iterdecode(ftpstream, self.encoding),
+                                    self._keys)
+                header = next(reader)   # Omit header row from output
+                for row in reader:
+                    self._length += 1
+                    yield row
+
+        else:
+            raise ValueError("Need a path_type")
+
+    @property
+    def keys(self):
+        return self._keys
+
+
+    def _download_data_file(self):
+        """
+        Internal function that tries to load the data file from the local file
+        system. If the file isn't found, it then downloads it.
+
+        :return: data file headers
+        """
+        headers = None
+        try:
+            with open(self.path, 'r', newline='', encoding=self.encoding) as f:
+                logging.info("  Defaulting to local data file: '{}'".format(self.path))
+                myreader = csv.reader(f, delimiter=',')
+                headers = next(myreader)
+        except FileNotFoundError as e:
+            self._validate_or_create_path()
+            logging.info("  File not found. Attempting to download file to disk: " +
+                         self.s3_path)
+            try:
+                urlretrieve(self.s3_path, self.path)
+                file_size = 0
+                if os.path.isfile(self.path):
+                    file_size = int(os.stat(self.path).st_size)
+                if file_size > 0:
+                    logging.info("  Download complete.  " \
+                                 "{} bytes downloaded.".format(file_size))
+                else:
+                    logging.warning("  Warning: Download cannot be verified; " \
+                                    "check location: '{}'".format(self.path))
+                    return
+                with open(self.path, 'r', newline='', encoding=self.encoding) as f:
+                    myreader = csv.reader(f,delimiter=',')
+                    headers = next(myreader)
+            except URLError as ue:
+                logging.error("  Error: _download_data_file(): " \
+                              "Error opening URL '{}' for download.".format(self.path))
+                raise
+            except OSError as oe:
+                logging.error("  Error: _download_data_file(): " \
+                              "Downloaded file '{}' cannot be opened " \
+                              "for reading.".format(oe.filename))
+                raise
+
+        return headers
 
     def _validate_or_create_path(self):
         """
@@ -234,27 +331,47 @@ class DataReader(HIReader):
         os.makedirs(root_path)
         return
 
-    def _download_data_file(self):
+    def _set_keys(self):
         """
-        Internal function that tries to load the data file from the local file
-        system. If the file isn't found, it then downloads it.
+        Internal function that returns the canonical header fieldname keys
+        dictionary.  (Removes any byte order mark detected in the leading header
+        fieldname key as read from the source file.)
 
-        :return: data file headers
+        :return: header fieldname keys dictionary (with any BOM removed)
         """
-
-        try:
-            with open(self.path, 'r', newline='') as f:
-                myreader = csv.reader(f, delimiter=',')
-                headers = next(myreader)
-        except FileNotFoundError as e:
-            self._validate_or_create_path()
-            logging.info("  file not found. attempting to download file to disk: " + self.s3_path)
-            urlretrieve(self.s3_path, self.path)
-            logging.info("  download complete.")
-            with open(self.path, 'r', newline='') as f:
-                myreader=csv.reader(f,delimiter=',')
-                headers = next(myreader)
-        return headers #not strictly necessary but useful for testing
+        _keys = None
+        if self.path_type == 'url':
+            logging.info("  File will be read from remote location: '{}'".format(self.path))
+            try:
+                with urlopen(self.path) as ftpstream:
+                    reader = DictReader(codecs.iterdecode(ftpstream, self.encoding))
+                    _keys = reader.fieldnames
+                    if self._contains_leading_bom(_keys[0], encoding=self.encoding):
+                        logging.info("  Leading BOM (byte order mark) found in file '{}'; " \
+                                     "updating header keys to omit BOM...".format(
+                                        os.path.basename(self.path)))
+                        _keys[0] = self._remove_leading_bom(_keys[0], self.encoding)
+            except URLError as ue:
+                logging.error("  Error: _set_keys(): Header fieldname keys cannot be set; " \
+                              "error opening URL '{}' for reading.".format(self.path))
+        else:
+            try:
+                with open(self.path, 'r', newline='', encoding=self.encoding) as data:
+                    reader = DictReader(data)
+                    _keys = reader.fieldnames
+                    if self._contains_leading_bom(_keys[0], encoding=self.encoding):
+                        logging.info("  Leading BOM (byte order mark) found in file '{}'; " \
+                                     "updating header keys to omit BOM...".format(
+                                        os.path.basename(self.path)))
+                        _keys[0] = self._remove_leading_bom(_keys[0], encoding=self.encoding)
+            except OSError as oe:
+                logging.error("  Error: _set_keys(): Header fieldname keys cannot be set; " \
+                              "file '{}' cannot be opened for reading.".format(oe.filename))
+                logging.error("  Full system error message:\n\n  '{}'".format(oe.strerror))
+            except ValueError as ve:
+                logging.error("  Error: _set_keys(): Header fieldname keys cannot be set; " \
+                              "encoding error encountered.")
+        return _keys
 
     def should_file_be_loaded(self, sql_manifest_row):
         """
@@ -290,7 +407,7 @@ class DataReader(HIReader):
                 return True
             if sql_manifest_row['status'] == 'loaded':
                 logging.info("  {} is already in the database, skipping".format(
-                    self.manifest_row['unique_data_id']))
+                                self.manifest_row['unique_data_id']))
                 return False
         else:
             logging.info("  {} include_flag is {}, skipping".format(
@@ -321,11 +438,11 @@ class DataReader(HIReader):
 
         #Log our errors if any
         if not success:
-            logging.warning("  do_fields_match: {}. '{}' had missing "
+            logging.warning("  do_fields_match: {}. '{}' had missing " \
                             "items:\n{}".format(success, self.destination_table,
                                                 self.not_found))
         else:
-            logging.info("  do_fields_match: {}. meta.json and csv field lists "
+            logging.info("  do_fields_match: {}. meta.json and csv field lists " \
                          "match completely for '{}'".format(
                             success, self.destination_table))
 
@@ -359,7 +476,190 @@ class DataReader(HIReader):
         for field in field_list:
             if (field['required_in_source']) and \
                     (field['source_name'] not in self.keys):
-                self.not_found.append('  "{}" in meta.json not found in '
+                self.not_found.append('  "{}" in meta.json not found in ' \
                                       'data'.format(field['source_name']))
                 success = False
         return success
+
+    def _test_connection_to_URL(self, url_str):
+        """
+        Internal function that tests the connection to a URL via a simple
+        HTTP/1.1 HEAD request.  If a test connection cannot be established,
+        raises an exception with a helpful diagnostic message (e.g. the
+        HTTP Response status code & reason).
+
+        :param url_str: full string for the URL to test a connection to
+        :type url_str: str
+
+        :return: the value of the HTTP Response 'Content-Type' header,
+                 or None if no successful test connection was made
+        """
+        content_type_header = None
+        try:
+            url = urlparse(url_str)
+            test_conn = None
+            if url.scheme == 'https':
+                test_conn = HTTPSConnection(url.netloc)
+            elif url.scheme == 'http':
+                test_conn = HTTPConnection(url.netloc)
+            else:
+                raise RuntimeError("  Error:  Cannot connect to URL '{}'\n" \
+                                   "  Unsupported network protocol scheme " \
+                                   "'{}' specified\n" \
+                                   "  Supported schemes: http | https".format(
+                                    url_str, url.scheme))
+            test_conn.request('HEAD', url.path)
+            response = test_conn.getresponse()
+            content_type_header = response.getheader('Content-Type')
+            if response.status != OK:    # i.e. "HTTP/1.1 200 OK"
+                raise RuntimeError("  Error: Cannot connect to URL '{}'\n" \
+                                   "  HTTP Response status code & reason: " \
+                                   "{} {}".format(url_str, response.status,
+                                                           response.reason))
+        except ValueError as ve:    # Raised by urlparse(...)
+            raise RuntimeError("  Error: Cannot connect to URL '{}'\n" \
+                               "  URL string may be invalid.".format(url_str))
+        except HTTPException as he: # Raised by HTTPSConnection(...)
+                                    # or HTTPConnection(...)
+            raise RuntimeError("  Error: Cannot connect to URL '{}'\n" \
+                               "  HTTPException: {}\n" \
+                               "  url.scheme : '{}'\n" \
+                               "  url.netloc : '{}'\n" \
+                               "  url.path   : '{}'\n".format(
+                                url_str, str(he),
+                                url.scheme, url.netloc, url.path))
+        except OSError as oe:   # Catches any low-level socket errors
+                                # raised by test_conn.request(...)
+                                # -> _socket (socketmodule.c)
+            raise RuntimeError("  Error: Cannot connect to URL '{}'\n" \
+                               "  Socket Error: {}: {}\n" \
+                               "  url.scheme : '{}'\n" \
+                               "  url.netloc : '{}'\n" \
+                               "  url.path   : '{}'\n".format(
+                                url_str, type(oe).__name__, str(oe),
+                                url.scheme, url.netloc, url.path))
+        finally:
+            if isinstance(test_conn, HTTPConnection):
+                test_conn.close()
+
+        return content_type_header
+
+    def _suppress_verbose_error_reporting(self):
+        """
+        Internal function that enables temporary suppression of verbose error
+        reporting of full stack traces accompanying exceptions.
+        Instead of printing to stderr, stack traces are logged to
+        the default logging instance.
+
+        Note: This is currently used to pass along brief diagnostic feedback
+              for connection/socket-level exceptions raised by
+              _test_connection_to_URL(...) while omitting stack traces in
+              stderr output.
+        """
+        # Save default exception-handling behavior:
+        self._error_reporting_overhead['sys.excepthook'] = sys.excepthook
+        # Temporarily set exception handling to custom exception handler that
+        # logs stack traces for debugging instead of printing them to stderr:
+        sys.excepthook = self._discreet_exception_handler
+        # Temporarily remove any StreamHandler instances for the default logger:
+        self._error_reporting_overhead['stream_handlers'] = []
+        stream_handlers = (h for h in logging.getLogger().handlers \
+                             if isinstance(h, logging.StreamHandler))
+        for h in stream_handlers:
+            self._error_reporting_overhead['stream_handlers'].append(h)
+            logging.getLogger().removeHandler(h)
+
+    def _restore_verbose_error_reporting(self):
+        """
+        Internal function that enables restores default error reporting that
+        both prints full stack traces accompanying exceptions to stderr and
+        logs them to the default logging instance.
+
+        Note: This is intended to be called after
+              _suppress_verbose_error_reporting() to restore normal error
+              handling behavior.
+        """
+        # Restore any StreamHandler instances for the default logger:
+        if len(self._error_reporting_overhead['stream_handlers']) > 0:
+            stream_handlers_indices = []
+            for i, h in enumerate(self._error_reporting_overhead['stream_handlers']):
+                logging.getLogger().addHandler(h)
+                stream_handlers_indices.append(i)
+            for j in stream_handlers_indices:
+                self._error_reporting_overhead['stream_handlers'].pop(j)
+        # Restore default exception-handling behavior to verbose
+        # (will print any stack traces to stderr again)
+        sys.excepthook = self._error_reporting_overhead['sys.excepthook']
+
+    def _discreet_exception_handler(self, exception_class, exception, tb):
+        """
+        Internal function that acts as a temporary exception handler.
+        Prints only the handled exception to stderr while logging any
+        accompanying stack traces to the default log.
+        """
+        logging.error("{}: {}".format(exception_class.__name__, exception))
+        logging.error("Traceback (most recent call last):")
+        tb_entries = traceback.extract_tb(tb)
+        for tb_entry in tb_entries:
+            logging.error("  File \"{}\", line {}, in {}\n" \
+                          "    {}".format(tb_entry[0], tb_entry[1], tb_entry[2],
+                                          tb_entry[3]))
+        print("{}: {}".format(exception_class.__name__, exception),
+              file=sys.stderr)
+
+    def _contains_leading_bom(self, str, encoding='utf-8'):
+        """
+        Returns True if input string starts with 0xEFBBBF byte order mark
+        sequence and False otherwise, testing the string according to
+        an optional encoding parameter (default is 'utf-8').
+
+        :param str: the string to evaluate
+        :type str: str
+
+        :param encoding: str encoding: 'utf-8' (default) | 'latin-1'
+        :type encoding: str
+
+        :return: True if str starts with BOM sequence, False otherwise
+        """
+        if (encoding == 'utf-8'):
+            bom_as_hex = "efbbbf"   # hex encoding of utf-8 BOM
+            str_as_hex = "".join("{:02x}".format(c) for c in str.encode())
+            if str_as_hex.startswith(bom_as_hex):
+                return True
+        elif (encoding == 'latin-1'):
+            bom_in_latin_1 = "ï»¿"  # latin-1-encoded version of BOM
+            if (str.startswith(bom_in_latin_1)):
+                return True
+        else:
+            logging.error("Unrecognized encoding: '{}'".format(encoding))
+        return False
+
+    def _remove_leading_bom(self, str, encoding='utf-8'):
+        """
+        Accepts an input string and optional encoding and returns the string
+        with any leading byte order mark stripped off.
+
+        :param str: the string to strip the BOM from
+        :type str: str
+
+        :param encoding: str encoding: 'utf-8' (default) | 'latin-1'
+        :type encoding: str
+
+        :return: input string with any leading BOM sequence removed
+        """
+        str_new = str
+        if (encoding == 'utf-8'):
+            bom_as_hex = "efbbbf"   # hex encoding of utf-8 BOM
+            str_as_hex = "".join("{:02x}".format(c) for c in str.encode())
+            if str_as_hex.startswith(bom_as_hex):
+                str_as_hex = "".join(str_as_hex.split(bom_as_hex,1)[1])
+                str_new = "".join("{}".format(chr(int(str_as_hex[i:i+2],16))) \
+                                              for i in range(0,len(str_as_hex),2))
+        elif (encoding == 'latin-1'):
+            bom_in_latin_1 = "ï»¿"  # latin-1-encoded version of BOM
+            if (str.startswith(bom_in_latin_1)):
+                str_new = "".join(str.split(bom_in_latin_1,1)[1])
+        else:
+            logging.error("Unrecognized encoding: '{}'".format(encoding))
+        return str_new
+

--- a/python/scripts/meta.json
+++ b/python/scripts/meta.json
@@ -547,7 +547,7 @@
     "replace_table": false
   },
   "dc_tax": {
-    "cleaner": "dc_tax_cleaner",
+    "cleaner": "DCTaxCleaner",
     "fields": [
       {
         "display_name": "objectid",

--- a/python/tests/test_DataReader_bom_handling.py
+++ b/python/tests/test_DataReader_bom_handling.py
@@ -1,0 +1,587 @@
+import sys, os
+import unittest
+sys.path.append(os.path.abspath('../'))
+
+import logging
+
+from urllib.request import urlopen
+
+from housinginsights.ingestion import DataReader, ManifestReader
+from housinginsights.ingestion import functions as ingestionfunctions
+
+
+this_file = os.path.realpath(__file__)
+this_dir  = os.path.dirname(this_file)
+backup_suffix = '.backup'
+
+meta_path     = os.path.abspath(this_dir + '/test_data/meta_bom_handling.json')    # TODO Update when meta.json is updated.
+manifest_path = os.path.abspath(this_dir + '/test_data/manifest_bom_handling.csv') # TODO Consider updating manifest_sample
+
+# Note: In order for unit tests to work properly, this class requires that:
+#       1. any test sample data file with a leading byte order mark (BOM)
+#          MUST be flagged as such in the manifest with a 'unique_data_id' that
+#          includes '_bom' as a substring.
+#       2. any test sample data file WITHOUT a leading byte order mark (BOM)
+#          MUST be flagged as such in the manifest with a 'unique_data_id' that
+#          includes '_nobom' as a substring.
+
+meta = ingestionfunctions.load_meta_data(meta_path)
+manifest = ManifestReader(manifest_path)
+
+logging.basicConfig(level=logging.INFO)
+
+# TODO: Update the logging message test match substrings below
+#       whenever specific INFO-level (and above) message text/behavior
+#       is changed in DataReader.py:
+LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE = "Content (MIME) type"                             # DataReader:__init__(...)
+LOG_MSG_MATCH_DEFAULT_TO_LOCAL      = "Defaulting to local data file"                   # DataReader:_download_data_file()
+LOG_MSG_MATCH_ATTEMPT_TO_DOWNLOAD   = "Attempting to download file to disk"             # DataReader:_download_data_file()
+LOG_MSG_MATCH_DOWNLOAD_COMPLETE     = "Download complete"                               # DataReader:_download_data_file()
+LOG_MSG_MATCH_REMOTE_FILE_ACCESS    = "File will be read from remote location"          # DataReader:_set_keys()
+LOG_MSG_MATCH_LEADING_BOM_FOUND     = "Leading BOM (byte order mark) found in file"     # DataReader:_set_keys()
+LOG_MSG_MATCH_HEADER_FIELDS_MATCH   = "meta.json and csv field lists match completely"  # DataReader:_do_fields_match()
+
+
+
+
+class BomHandlingCase(unittest.TestCase):
+
+    # Rename any pre-existing data file(s) in preparation for testing
+    # load_from='file' triggering download
+    def setUp(self):
+        print("Performing setUp() preparation...\n\n")
+        for manifest_row in manifest:
+            if manifest_row['include_flag'] == 'use':
+                sample_data_folder_path = manifest_row['local_folder']
+                # Adjust relative path for our location (parent directory of test_data/); strip off leading '../'
+                if sample_data_folder_path[:3] == '../':
+                    sample_data_folder_path = sample_data_folder_path[3:]
+                    sample_data_file_path = sample_data_folder_path + '/' + manifest_row['filepath']
+                else:
+                    print("  Unexpected local sample data file relative path : '{}'".format(sample_data_file_path))
+                    print("  Please resolve this issue.")
+                    print("Exiting test...")
+                    system.exit()
+                if os.path.isfile(sample_data_file_path):
+                    os.replace(sample_data_file_path, sample_data_file_path + backup_suffix)
+
+    # Restore any pre-existing data file(s) renamed in setUp()
+    def tearDown(self):
+        print("Performing tearDown() cleanup...\n\n")
+        for manifest_row in manifest:
+            if manifest_row['include_flag'] == 'use':
+                backup_sample_data_file_path = manifest_row['local_folder']+'/'+manifest_row['filepath']+'.backup'
+                # Adjust relative file path for our location (parent directory of test_data/); strip off leading '../'
+                if backup_sample_data_file_path[:3] == '../':
+                    backup_sample_data_file_path = backup_sample_data_file_path[3:]
+                if os.path.isfile(backup_sample_data_file_path):
+                    truncate_index = len(backup_sample_data_file_path) - len(backup_suffix)
+                    orig_sample_data_file_path = backup_sample_data_file_path[:truncate_index]
+                    os.replace(backup_sample_data_file_path, orig_sample_data_file_path)
+
+
+class TestBomHandling(BomHandlingCase):
+
+    def test_bom_handling(self):
+
+        print("Running test_bom_handling()...\n\n")
+
+        for manifest_row in manifest:
+            if manifest_row['include_flag'] == 'use':
+                unique_data_id = manifest_row['unique_data_id']
+
+                sample_data_folder_path = manifest_row['local_folder']
+                local_sample_data_file = sample_data_folder_path + '/' + manifest_row['filepath']
+                # Adjust relative path for our location (parent directory of test_data/); strip off leading '../'
+                if sample_data_folder_path[:3] == '../':
+                    sample_data_folder_path = sample_data_folder_path[3:]
+                    local_sample_data_file = sample_data_folder_path + '/' + manifest_row['filepath']
+
+
+                # Test Case 1: Test sample data file with bom in header row
+                if "_bom" in unique_data_id:
+
+                    print("  Test Case 1: Test sample data file with bom in header row...\n\n")
+
+                    self.assertIn("_bom", unique_data_id)
+
+                    # Subtest Case 1a: File with bom in header row:
+                    #                  load_from='file': Sample data file does not already exist
+                    #                  locally and DataReader downloads remote file
+                    with self.subTest(subtest='1a'):
+                        subtest1a_success = self._test_bom_handling_case_1a(manifest_row,
+                                                                            local_sample_data_file)
+                        self.assertTrue(subtest1a_success, "If failed, test case 1a failed.\n")
+
+                    # Subtest Case 1b: File with bom in header row:
+                    #                  load_from='file': Sample data file already exists locally and
+                    #                  DataReader reads from local file
+                    with self.subTest(subtest='1b'):
+                        subtest1b_success = self._test_bom_handling_case_1b(manifest_row,
+                                                                            local_sample_data_file)
+                        self.assertTrue(subtest1b_success, "If failed, test case 1b failed.\n")
+
+                    # Subtest Case 1c: File with bom in header row:
+                    #                  load_from='s3': DataReader reads from remote file
+                    with self.subTest(subtest='1c'):
+                        subtest1c_success = self._test_bom_handling_case_1c(manifest_row,
+                                                                            local_sample_data_file)
+                        self.assertTrue(subtest1c_success, "If failed, test case 1c failed.\n")
+
+
+                # Test Case 2: Test sample data file without bom in header row
+                else:
+
+                    print("  Test Case 2: Test sample data file without bom in header row...\n\n")
+
+                    self.assertIn("_nobom", unique_data_id)
+
+                    # Subtest Case 2a: File without bom in header row:
+                    #                  load_from='file': Sample data file does not already exist
+                    #                  locally and DataReader downloads remote file
+                    with self.subTest(subtest='2a'):
+                        subtest2a_success = self._test_bom_handling_case_2a(manifest_row,
+                                                                            local_sample_data_file)
+                        self.assertTrue(subtest2a_success, "If failed, test case 2a failed.\n")
+
+                    # Subtest Case 2b: File without bom in header row:
+                    #                  load_from='file': Sample data file already exists locally and
+                    #                  DataReader reads from local file
+                    with self.subTest(subtest='2b'):
+                        subtest2b_success = self._test_bom_handling_case_2b(manifest_row,
+                                                                            local_sample_data_file)
+                        self.assertTrue(subtest2b_success, "If failed, test case 2b failed.\n")
+
+                    # Subtest Case 2c: File without bom in header row:
+                    #                  load_from='s3': DataReader reads from remote file
+                    with self.subTest(subtest='2c'):
+                        subtest2c_success = self._test_bom_handling_case_2c(manifest_row,
+                                                                            local_sample_data_file)
+                        self.assertTrue(subtest2c_success, "If failed, test case 2c failed.\n")
+
+
+
+    # Subtest Case 1a: File with bom in header row:
+    #                  load_from='file': Sample data file does not already exist locally
+    #                  and DataReader downloads remote file
+    def _test_bom_handling_case_1a(self, manifest_row, local_sample_data_file):
+
+        print("    Subtest Case 1a: Test sample data file with bom in header row:")
+        print("                     load_from='file': Sample data file does not already \n" \
+              "                     exist locally and DataReader downloads remote file\n")
+
+        print("      Test File: '{}'\n".format(local_sample_data_file))
+
+        unique_data_id = manifest_row['unique_data_id']
+
+        case_name = "DataReader instantiation for input '{}' with BOM header, " \
+                    "triggered remote download case.".format(unique_data_id)
+
+        self.assertFalse(os.path.isfile(local_sample_data_file),
+                         "If failed, input file '{}' unexpectedly exists already. ({})".format(
+                            os.path.basename(local_sample_data_file), case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            csv_reader = DataReader(meta=meta, manifest_row=manifest_row, load_from='file')
+        self.assertIsInstance(csv_reader, DataReader,
+                              "If failed, DataReader was not instantiated. ({})".format(case_name))
+        self.assertGreater(len(logged.output), 0,
+                           "If failed, no output was logged as expected. ({})".format(case_name))
+        if len(logged.output) == 4:
+            self.assertIn(LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, logged.output[0],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, case_name))
+            self.assertIn(LOG_MSG_MATCH_ATTEMPT_TO_DOWNLOAD  , logged.output[1],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_ATTEMPT_TO_DOWNLOAD  , case_name))
+            self.assertIn(LOG_MSG_MATCH_DOWNLOAD_COMPLETE    , logged.output[2],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_DOWNLOAD_COMPLETE  , case_name))
+            self.assertIn(LOG_MSG_MATCH_LEADING_BOM_FOUND    , logged.output[3],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_LEADING_BOM_FOUND  , case_name))
+        else: # Force test failure:
+            self.assertEqual(len(logged.output), 4,
+                             "If failed, there was a different number of output lines than expected. " \
+                             "({})".format(case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            fields_match_success = csv_reader._do_fields_match()
+        self.assertTrue(fields_match_success,
+                        "If failed, sample meta.json and data file header field names did not match. " \
+                        "({})".format(case_name))
+        self.assertIn(LOG_MSG_MATCH_HEADER_FIELDS_MATCH, logged.output[0],
+                      "If failed, sample meta.json and data file header field names did not match. " \
+                      "({})\n" \
+                      "If failed, double-check that 'source_name' values in '{}' fully match " \
+                      "csv header field names in '{}'.".format(
+                        case_name, os.path.basename(meta_path),
+                                   os.path.basename(local_sample_data_file)))
+
+        with open(local_sample_data_file, mode='r', encoding=manifest_row['encoding']) as f:
+            # Get array of data row lines from source sample data file to compare against DataReader data row:
+            data_lines_file = f.read().replace('"', '').replace("\r\n", "\n").split('\n')[1:]
+        for i,d in enumerate(csv_reader):
+            # Convert DataReader data row dicts into csv strings and compare to file data row lines:
+            data_row_csv = ','.join(d[k] for k in csv_reader.keys)
+            self.assertEqual(data_lines_file[i], data_row_csv)
+        with open(local_sample_data_file, mode='rb') as f:
+            # Verify that source sample data file has BOM:
+            self.assertEqual(f.read(3).hex(), "efbbbf")
+
+        print("    Subtest Case 1a: Tests completed successfully.\n\n")
+        return True
+
+
+    # Subtest Case 1b: File with bom in header row:
+    #                  load_from='file': Sample data file already exists locally
+    #                  and DataReader reads from local file
+    def _test_bom_handling_case_1b(self, manifest_row, local_sample_data_file):
+
+        print("    Subtest Case 1b: Test sample data file with bom in header row:")
+        print("                     load_from='file': Sample data file already exists locally \n" \
+              "                     and DataReader reads from local file\n")
+
+        print("      Test File: '{}'\n".format(local_sample_data_file))
+
+        unique_data_id = manifest_row['unique_data_id']
+
+        case_name = "DataReader instantiation for input '{}' with BOM header, " \
+                    "local file case.".format(unique_data_id)
+
+        self.assertTrue(os.path.isfile(local_sample_data_file),
+                        "If failed, input file '{}' not found locally as expected. ({})".format(
+                            os.path.basename(local_sample_data_file), case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            csv_reader = DataReader(meta=meta, manifest_row=manifest_row, load_from='file')
+        self.assertIsInstance(csv_reader, DataReader,
+                              "If failed, DataReader was not instantiated. ({})".format(case_name))
+        self.assertGreater(len(logged.output), 0,
+                           "If failed, no output was logged as expected. ({})".format(case_name))
+        if len(logged.output) == 3:
+            self.assertIn(LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, logged.output[0],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, case_name))
+            self.assertIn(LOG_MSG_MATCH_DEFAULT_TO_LOCAL     , logged.output[1],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_DEFAULT_TO_LOCAL     , case_name))
+            self.assertIn(LOG_MSG_MATCH_LEADING_BOM_FOUND    , logged.output[2],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_LEADING_BOM_FOUND    , case_name))
+        else: # Force test failure:
+            self.assertEqual(len(logged.output), 3,
+                             "If failed, there was a different number of output lines than expected. " \
+                             "({})".format(case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            fields_match_success = csv_reader._do_fields_match()
+        self.assertTrue(fields_match_success,
+                        "If failed, sample meta.json and data file header field names did not match. " \
+                        "({})".format(case_name))
+        self.assertIn(LOG_MSG_MATCH_HEADER_FIELDS_MATCH, logged.output[0],
+                      "If failed, sample meta.json and data file header field names did not match. " \
+                      "({})\n" \
+                      "If failed, double-check that 'source_name' values in '{}' fully match " \
+                      "csv header field names in '{}'.".format(
+                        case_name, os.path.basename(meta_path),
+                                   os.path.basename(local_sample_data_file)))
+
+        with open(local_sample_data_file, mode='r', encoding=manifest_row['encoding']) as f:
+            # Get array of data row lines from source sample data file to compare against DataReader data row:
+            data_lines_file = f.read().replace('"', '').replace("\r\n", "\n").split('\n')[1:]
+        for i,d in enumerate(csv_reader):
+            # Convert DataReader data row dicts into csv strings and compare to file data row lines:
+            data_row_csv = ','.join(d[k] for k in csv_reader.keys)
+            self.assertEqual(data_lines_file[i], data_row_csv)
+        with open(local_sample_data_file, mode='rb') as f:
+            # Verify that source sample data file has BOM:
+            self.assertEqual(f.read(3).hex(), "efbbbf")
+
+        print("    Subtest Case 1b: Tests completed successfully.\n\n")
+        return True
+
+
+    # Subtest Case 1c: File with bom in header row:
+    #                  load_from='s3': DataReader reads from remote file
+    def _test_bom_handling_case_1c(self, manifest_row, local_sample_data_file):
+
+        print("    Subtest Case 1c: Test sample data file with bom in header row:")
+        print("                     load_from='s3': DataReader reads from remote file\n")
+
+        print("      Test File: '{}'\n".format(local_sample_data_file))
+
+        unique_data_id = manifest_row['unique_data_id']
+
+        case_name = "DataReader instantiation for input '{}' with BOM header, " \
+                    "read from remote file case.".format(unique_data_id)
+
+        with self.assertLogs(level='INFO') as logged:
+            csv_reader = DataReader(meta=meta, manifest_row=manifest_row, load_from='s3')
+        self.assertIsInstance(csv_reader, DataReader,
+                              "If failed, DataReader was not instantiated. ({})".format(case_name))
+        self.assertGreater(len(logged.output), 0,
+                           "If failed, no output was logged as expected. ({})".format(case_name))
+        if len(logged.output) == 3:
+            self.assertIn(LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, logged.output[0],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, case_name))
+            self.assertIn(LOG_MSG_MATCH_REMOTE_FILE_ACCESS   , logged.output[1],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_REMOTE_FILE_ACCESS   , case_name))
+            self.assertIn(LOG_MSG_MATCH_LEADING_BOM_FOUND    , logged.output[2],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_LEADING_BOM_FOUND    , case_name))
+        else: # Force test failure:
+            self.assertEqual(len(logged.output), 3,
+                             "If failed, there was a different number of output lines than expected. " \
+                             "({})".format(case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            fields_match_success = csv_reader._do_fields_match()
+        self.assertTrue(fields_match_success,
+                        "If failed, sample meta.json and data file header field names did not match. " \
+                        "({})".format(case_name))
+        self.assertIn(LOG_MSG_MATCH_HEADER_FIELDS_MATCH, logged.output[0],
+                      "If failed, sample meta.json and data file header field names did not match. " \
+                      "({})\n" \
+                      "If failed, double-check that 'source_name' values in '{}' fully match " \
+                      "csv header field names in '{}'.".format(
+                        case_name, os.path.basename(meta_path),
+                                   os.path.basename(local_sample_data_file)))
+
+        s3_path = os.path.join( manifest_row['s3_folder'],
+                                manifest_row['filepath'].strip("\/") ).replace("\\","/")
+        with urlopen(s3_path) as ftpstream:
+            # Verify that source sample data file has BOM:
+            header_line_file = ftpstream.readline().decode('latin-1')
+            self.assertEqual(header_line_file[:3], "ï»¿")
+            for i,d in enumerate(csv_reader):
+                data_line_file = ftpstream.readline().decode(manifest_row['encoding']).replace('"', '').replace("\n", '')
+                if data_line_file == b'':
+                    break
+                # Convert DataReader data row dicts into csv string and compare to file data row line:
+                data_row_csv = ','.join(d[k] for k in csv_reader.keys)
+                self.assertEqual(data_line_file, data_row_csv)
+
+        print("    Subtest Case 1c: Tests completed successfully.\n\n")
+        return True
+
+
+    # Subtest Case 2a: File without bom in header row:
+    #                  load_from='file': Sample data file does not already exist locally
+    #                  and DataReader downloads remote file
+    def _test_bom_handling_case_2a(self, manifest_row, local_sample_data_file):
+
+        print("    Subtest Case 2a: Test sample data file without bom in header row:")
+        print("                     load_from='file': Sample data file does not already exist locally \n" \
+              "                     and DataReader downloads remote file\n")
+
+        print("      Test File: '{}'\n".format(local_sample_data_file))
+
+        unique_data_id = manifest_row['unique_data_id']
+
+        case_name = "DataReader instantiation for input '{}' without BOM header, " \
+                    "triggered remote download case.".format(unique_data_id)
+
+        self.assertFalse(os.path.isfile(local_sample_data_file),
+                         "If failed, input file '{}' unexpectedly exists already. ({})".format(
+                            os.path.basename(local_sample_data_file), case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            csv_reader = DataReader(meta=meta, manifest_row=manifest_row, load_from='file')
+        self.assertIsInstance(csv_reader, DataReader,
+                              "If failed, DataReader was not instantiated. ({})".format(case_name))
+
+        self.assertGreater(len(logged.output), 0,
+                           "If failed, no output was logged as expected. ({})".format(case_name))
+        if len(logged.output) == 3:
+            self.assertNotIn(LOG_MSG_MATCH_LEADING_BOM_FOUND  , logged.output[0],
+                             "If failed, unexpected '{}' found in logged output. ({})".format(
+                                LOG_MSG_MATCH_LEADING_BOM_FOUND, case_name))
+            self.assertNotIn(LOG_MSG_MATCH_LEADING_BOM_FOUND  , logged.output[1],
+                             "If failed, unexpected '{}' found in logged output. ({})".format(
+                                LOG_MSG_MATCH_LEADING_BOM_FOUND, case_name))
+            self.assertNotIn(LOG_MSG_MATCH_LEADING_BOM_FOUND  , logged.output[2],
+                             "If failed, unexpected '{}' found in logged output. ({})".format(
+                                LOG_MSG_MATCH_LEADING_BOM_FOUND, case_name))
+
+            self.assertIn(LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, logged.output[0],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, case_name))
+            self.assertIn(LOG_MSG_MATCH_ATTEMPT_TO_DOWNLOAD  , logged.output[1],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_ATTEMPT_TO_DOWNLOAD  , case_name))
+            self.assertIn(LOG_MSG_MATCH_DOWNLOAD_COMPLETE    , logged.output[2],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_DOWNLOAD_COMPLETE    , case_name))
+        else: # Force test failure:
+            self.assertEqual(len(logged.output), 3,
+                             "If failed, there was a different number of output lines than expected. " \
+                             "({})".format(case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            fields_match_success = csv_reader._do_fields_match()
+        self.assertTrue(fields_match_success,
+                        "If failed, sample meta.json and data file header field names did not match. " \
+                        "({})".format(case_name))
+        self.assertIn(LOG_MSG_MATCH_HEADER_FIELDS_MATCH, logged.output[0],
+                      "If failed, sample meta.json and data file header field names did not match. " \
+                      "({})\n" \
+                      "If failed, double-check that 'source_name' values in '{}' fully match " \
+                      "csv header field names in '{}'.".format(
+                        case_name, os.path.basename(meta_path),
+                                   os.path.basename(local_sample_data_file)))
+
+        with open(local_sample_data_file, mode='r', encoding=manifest_row['encoding']) as f:
+            # Get data row lines from source sample data file to compare against DataReader data row:
+            data_lines_file = f.read().replace('"', '').replace("\r\n", "\n").split('\n')[1:]
+        for i,d in enumerate(csv_reader):
+            # Convert DataReader data row dicts into csv strings and compare to file data row lines:
+            data_row_csv = ','.join(d[k] for k in csv_reader.keys)
+            self.assertEqual(data_lines_file[i], data_row_csv)
+
+        print("    Subtest Case 2a: Tests completed successfully.\n\n")
+        return True
+
+
+    # Subtest Case 2b: File without bom in header row:
+    #                  load_from='file': Sample data file already exists locally
+    #                  and DataReader reads from local file
+    def _test_bom_handling_case_2b(self, manifest_row, local_sample_data_file):
+
+        print("    Subtest Case 2b: Test sample data file without bom in header row:")
+        print("                     load_from='file': Sample data file already exists locally \n" \
+              "                     and DataReader reads from local file\n")
+
+        print("      Test File: '{}'\n".format(local_sample_data_file))
+
+        unique_data_id = manifest_row['unique_data_id']
+
+        case_name = "DataReader instantiation for input '{}' without BOM header, " \
+                    "local file case.".format(unique_data_id)
+
+        self.assertTrue(os.path.isfile(local_sample_data_file),
+                        "If failed, input file '{}' not found locally as expected. ({})".format(
+                            os.path.basename(local_sample_data_file), case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            csv_reader = DataReader(meta=meta, manifest_row=manifest_row, load_from='file')
+        self.assertIsInstance(csv_reader, DataReader,
+                              "If failed, DataReader was not instantiated. ({})".format(case_name))
+        self.assertGreater(len(logged.output), 0,
+                           "If failed, no output was logged as expected. ({})".format(case_name))
+        if len(logged.output) == 2:
+            self.assertNotIn(LOG_MSG_MATCH_LEADING_BOM_FOUND, logged.output[0],
+                             "If failed, unexpected '{}' found in logged output. ({})".format(
+                                LOG_MSG_MATCH_LEADING_BOM_FOUND, case_name))
+            self.assertNotIn(LOG_MSG_MATCH_LEADING_BOM_FOUND, logged.output[1],
+                             "If failed, unexpected '{}' found in logged output. ({})".format(
+                                LOG_MSG_MATCH_LEADING_BOM_FOUND, case_name))
+
+            self.assertIn(LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, logged.output[0],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, case_name))
+            self.assertIn(LOG_MSG_MATCH_DEFAULT_TO_LOCAL     , logged.output[1],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_DEFAULT_TO_LOCAL     , case_name))
+        else: # Force test failure:
+            self.assertGreater(len(logged.output), 2,
+                               "If failed, there were more output lines logged than expected. " \
+                               "({})".format(case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            fields_match_success = csv_reader._do_fields_match()
+        self.assertTrue(fields_match_success,
+                        "If failed, sample meta.json and data file header field names did not match. " \
+                        "({})".format(case_name))
+        self.assertIn(LOG_MSG_MATCH_HEADER_FIELDS_MATCH, logged.output[0],
+                      "If failed, sample meta.json and data file header field names did not match. " \
+                      "({})\n" \
+                      "If failed, double-check that 'source_name' values in '{}' fully match " \
+                      "csv header field names in '{}'.".format(
+                        case_name, os.path.basename(meta_path),
+                                   os.path.basename(local_sample_data_file)))
+
+        with open(local_sample_data_file, mode='r', encoding=manifest_row['encoding']) as f:
+            # Get array of data row lines from source sample data file to compare against DataReader data row:
+            data_lines_file = f.read().replace('"', '').replace("\r\n", "\n").split('\n')[1:]
+        for i,d in enumerate(csv_reader):
+            # Convert DataReader data row dicts into csv strings and compare to file data row lines:
+            data_row_csv = ','.join(d[k] for k in csv_reader.keys)
+            self.assertEqual(data_lines_file[i], data_row_csv)
+
+        print("    Subtest Case 2b: Tests completed successfully.\n\n")
+        return True
+
+
+    # Subtest Case 2c: File without bom in header row:
+    #                  load_from='s3': DataReader reads from remote file
+    def _test_bom_handling_case_2c(self, manifest_row, local_sample_data_file):
+
+        print("    Subtest Case 2c: Test sample data file without bom in header row:")
+        print("                     load_from='s3': DataReader reads from remote file\n")
+
+        print("      Test File: '{}'\n".format(local_sample_data_file))
+
+        unique_data_id = manifest_row['unique_data_id']
+
+        case_name = "DataReader instantiation for input '{}' without BOM header, " \
+                    "read from remote file case.".format(unique_data_id)
+
+        with self.assertLogs(level='INFO') as logged:
+            csv_reader = DataReader(meta=meta, manifest_row=manifest_row, load_from='s3')
+        self.assertIsInstance(csv_reader, DataReader,
+                              "If failed, DataReader was not instantiated. ({})".format(case_name))
+        self.assertGreater(len(logged.output), 0,
+                           "If failed, no output was logged as expected. ({})".format(case_name))
+        if len(logged.output) == 2:
+            self.assertNotIn(LOG_MSG_MATCH_LEADING_BOM_FOUND , logged.output[0],
+                             "If failed, unexpected '{}' found in logged output. ({})".format(
+                                LOG_MSG_MATCH_LEADING_BOM_FOUND, case_name))
+            self.assertNotIn(LOG_MSG_MATCH_LEADING_BOM_FOUND , logged.output[1],
+                             "If failed, unexpected '{}' found in logged output. ({})".format(
+                                LOG_MSG_MATCH_LEADING_BOM_FOUND, case_name))
+
+            self.assertIn(LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, logged.output[0],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_HTTP_HDR_CONTENT_TYPE, case_name))
+            self.assertIn(LOG_MSG_MATCH_REMOTE_FILE_ACCESS   , logged.output[1],
+                          "If failed, missing expected '{}' in logged output. ({})".format(
+                            LOG_MSG_MATCH_REMOTE_FILE_ACCESS   , case_name))
+        else: # Force test failure:
+            self.assertEqual(len(logged.output), 2,
+                             "If failed, there was a different number of output lines than expected. " \
+                             "({})".format(case_name))
+
+        with self.assertLogs(level='INFO') as logged:
+            fields_match_success = csv_reader._do_fields_match()
+        self.assertTrue(fields_match_success,
+                        "If failed, sample meta.json and data file header field names did not match. " \
+                        "({})".format(case_name))
+        self.assertIn(LOG_MSG_MATCH_HEADER_FIELDS_MATCH, logged.output[0],
+                      "If failed, sample meta.json and data file header field names did not match. " \
+                      "({})\n" \
+                      "If failed, double-check that 'source_name' values in '{}' fully match " \
+                      "csv header field names in '{}'.".format(
+                        case_name, os.path.basename(meta_path),
+                                   os.path.basename(local_sample_data_file)))
+
+        s3_path = os.path.join(manifest_row['s3_folder'], manifest_row['filepath'].strip("\/")).replace("\\","/")
+        with urlopen(s3_path) as ftpstream:
+            ftpstream.readline()    # Ignore header row of remote sample source data file
+            for i,d in enumerate(csv_reader):
+                data_line_file = ftpstream.readline().decode(manifest_row['encoding']).replace('"', '').replace('\r', '').replace('\n', '')
+                if data_line_file == b'':
+                    break
+                # Convert DataReader data row dicts into csv string and compare to remote file data row line:
+                data_row_csv = ','.join(d[k] for k in csv_reader.keys)
+                self.assertEqual(data_line_file, data_row_csv)
+
+        print("    Subtest Case 2c: Tests completed successfully.\n\n")
+        return True
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/test_data/manifest_bom_handling.csv
+++ b/python/tests/test_data/manifest_bom_handling.csv
@@ -1,0 +1,18 @@
+include_flag,destination_table,unique_data_id,data_date,encoding,local_folder,s3_folder,filepath,notes
+____City Development Data__,,,,,,,,
+use,building_permits,building_permits_test_bom,2/2/2017,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,sample/building_permits_bom_sample.csv,File has leading byte order mark (BOM); Testing BOM handling by DataReader (Ref: Issue #133)
+_____Crosswalks_____,,,,,,,,
+_____Neighborhood Info_____,,,,,,,,
+_____Preservation Catalog_____,,,,,,,,
+_____Planned Unit Developments_____,,,,,,,,
+_____Property Tax_____,,,,,,,,
+use,dc_tax,dc_tax_test_bom_20170515,5/15/2017,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,raw/tax_assessment/IntTaxSysPubExtFacts/20170515/Integrated_Tax_System_Public_Extract_Facts.csv,Downloaded from: http://opendata.dc.gov/datasets/014f4b4f94ea461498bfeba877d92319_56 ; File has leading byte order mark (BOM); Testing BOM handling by DataReader (Ref: Issue #133)
+use,dc_tax,dc_tax_test_bom_20170315,3/15/2017,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,sample/dc_tax_bom_sample.csv,File has leading byte order mark (BOM); Testing BOM handling by DataReader (Ref: Issue #133)
+_____Other DC Affordable Housing Data_____,,,,,,,,
+_____Market Rate Rent_____,,,,,,,,
+_____ACS Rent_____,,,,,,,,
+use,census,acs_rent_median_test_nobom,7/1/2012,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,sample/acs_median_rent_sample.csv,File does *not* have leading byte order mark (BOM); Testing BOM handling by DataReader (Ref: Issue #133)
+____Crime Data____,,,,,,,,
+____WMATA Data____,,,,,,,,
+
+

--- a/python/tests/test_data/meta_bom_handling.json
+++ b/python/tests/test_data/meta_bom_handling.json
@@ -1,0 +1,709 @@
+{
+  "census": {
+    "cleaner": "CensusCleaner",
+    "fields": [
+      {
+        "display_name": "geo_id",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "GEO.id",
+        "sql_name": "geo_id",
+        "type": "text"
+      },
+      {
+        "display_name": "Census tract code",
+        "display_text": "GEO.id2 in the source data, the code for the census tract including the state (11) and county (001) codes.",
+        "required_in_source": true,
+        "source_name": "GEO.id2",
+        "sql_name": "census_tract",
+        "type": "text"
+      },
+      {
+        "display_name": "Census tract description",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "GEO.display-label",
+        "sql_name": "census_tract_desc",
+        "type": "text"
+      },
+      {
+        "display_name": "Median Rent (ACS)",
+        "display_text": "Median rent paid by all residents in this area, per the American Community Survey Table B25058",
+        "required_in_source": true,
+        "source_name": "HD01_VD01",
+        "sql_name": "acs_median_rent",
+        "type": "integer"
+      },
+      {
+        "display_name": "MOE: Median Rent (ACS)",
+        "display_text": "Margin of error of the Median Rent in the American Community Survey Table B25058",
+        "required_in_source": true,
+        "source_name": "HD02_VD01",
+        "sql_name": "acs_median_rent_moe",
+        "type": "integer"
+      },
+      {
+        "_comment": "This will be added back in when the Census API tool is done",
+        "display_name": "Lower quartile rent (ACS)",
+        "display_text": "Lower quartile rent from the American Community Survey table B25057",
+        "required_in_source": false,
+        "source_name": "lower_quartile_rent",
+        "sql_name": "lower_quartile_rent",
+        "type": "integer"
+      },
+      {
+        "display_name": "Unique data ID",
+        "display_text": "Identifies which source file this record came from",
+        "required_in_source": false,
+        "source_name": "unique_data_id",
+        "sql_name": "unique_data_id",
+        "type": "text"
+      }
+    ],
+    "replace_table": false
+  },
+  "building_permits": {
+    "cleaner": "BuildingPermitsCleaner",
+    "fields": [
+      {
+        "display_name": "x",
+        "display_text": "Longitude field should be used instead",
+        "required_in_source": true,
+        "source_name": "X",
+        "sql_name": "x",
+        "type": "decimal"
+      },
+      {
+        "display_name": "y",
+        "display_text": "Latitude field should be used instead",
+        "required_in_source": true,
+        "source_name": "Y",
+        "sql_name": "y",
+        "type": "decimal"
+      },
+      {
+        "display_name": "objectid",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OBJECTID",
+        "sql_name": "objectid",
+        "type": "text"
+      },
+      {
+        "display_name": "dcrainternalnumber",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "DCRAINTERNALNUMBER",
+        "sql_name": "dcrainternalnumber",
+        "type": "text"
+      },
+      {
+        "display_name": "issue_date",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ISSUE_DATE",
+        "sql_name": "issue_date",
+        "type": "timestamp"
+      },
+      {
+        "display_name": "permit_id",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PERMIT_ID",
+        "sql_name": "permit_id",
+        "type": "text"
+      },
+      {
+        "display_name": "permit_type_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PERMIT_TYPE_NAME",
+        "sql_name": "permit_type_name",
+        "type": "text"
+      },
+      {
+        "display_name": "permit_subtype_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PERMIT_SUBTYPE_NAME",
+        "sql_name": "permit_subtype_name",
+        "type": "text"
+      },
+      {
+        "display_name": "permit_category_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PERMIT_CATEGORY_NAME",
+        "sql_name": "permit_category_name",
+        "type": "text"
+      },
+      {
+        "display_name": "application_status_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPLICATION_STATUS_NAME",
+        "sql_name": "application_status_name",
+        "type": "text"
+      },
+      {
+        "display_name": "full_address",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "FULL_ADDRESS",
+        "sql_name": "full_address",
+        "type": "text"
+      },
+      {
+        "display_name": "desc_of_work",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "DESC_OF_WORK",
+        "sql_name": "desc_of_work",
+        "type": "text"
+      },
+      {
+        "display_name": "ssl",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SSL",
+        "sql_name": "ssl",
+        "type": "text"
+      },
+      {
+        "display_name": "zoning",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ZONING",
+        "sql_name": "zoning",
+        "type": "text"
+      },
+      {
+        "display_name": "permit_applicant",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PERMIT_APPLICANT",
+        "sql_name": "permit_applicant",
+        "type": "text"
+      },
+      {
+        "display_name": "fee_type",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "FEE_TYPE",
+        "sql_name": "fee_type",
+        "type": "text"
+      },
+      {
+        "display_name": "fees_paid",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "FEES_PAID",
+        "sql_name": "fees_paid",
+        "type": "decimal"
+      },
+      {
+        "display_name": "owner_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OWNER_NAME",
+        "sql_name": "owner_name",
+        "type": "text"
+      },
+      {
+        "display_name": "Last Modified Date",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LASTMODIFIEDDATE",
+        "sql_name": "lastmodifieddate",
+        "type": "timestamp"
+      },
+      {
+        "display_name": "city",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CITY",
+        "sql_name": "city",
+        "type": "text"
+      },
+      {
+        "display_name": "state",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "STATE",
+        "sql_name": "state",
+        "type": "text"
+      },
+      {
+        "display_name": "latitude",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LATITUDE",
+        "sql_name": "latitude",
+        "type": "decimal"
+      },
+      {
+        "display_name": "longitude",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LONGITUDE",
+        "sql_name": "longitude",
+        "type": "decimal"
+      },
+      {
+        "display_name": "xcoord",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "XCOORD",
+        "sql_name": "xcoord",
+        "type": "decimal"
+      },
+      {
+        "display_name": "ycoord",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "YCOORD",
+        "sql_name": "ycoord",
+        "type": "decimal"
+      },
+      {
+        "display_name": "zipcode",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ZIPCODE",
+        "sql_name": "zipcode",
+        "type": "text"
+      },
+      {
+        "display_name": "maraddressrepositoryid",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "MARADDRESSREPOSITORYID",
+        "sql_name": "maraddressrepositoryid",
+        "type": "text"
+      },
+      {
+        "display_name": "dcstataddresskey",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "DCSTATADDRESSKEY",
+        "sql_name": "dcstataddresskey",
+        "type": "text"
+      },
+      {
+        "display_name": "dcstatlocationkey",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "DCSTATLOCATIONKEY",
+        "sql_name": "dcstatlocationkey",
+        "type": "text"
+      },
+      {
+        "display_name": "ward",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "WARD",
+        "sql_name": "ward",
+        "type": "text"
+      },
+      {
+        "display_name": "ANC",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ANC",
+        "sql_name": "anc",
+        "type": "text"
+      },
+      {
+        "display_name": "smd",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SMD",
+        "sql_name": "smd",
+        "type": "text"
+      },
+      {
+        "display_name": "district",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "DISTRICT",
+        "sql_name": "district",
+        "type": "text"
+      },
+      {
+        "display_name": "psa",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PSA",
+        "sql_name": "psa",
+        "type": "text"
+      },
+      {
+        "display_name": "neighborhoodcluster",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "NEIGHBORHOODCLUSTER",
+        "sql_name": "neighborhood_cluster",
+        "type": "text"
+      },
+      {
+        "display_name": "hotspot2006name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "HOTSPOT2006NAME",
+        "sql_name": "hotspot2006name",
+        "type": "text"
+      },
+      {
+        "display_name": "hotspot2005name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "HOTSPOT2005NAME",
+        "sql_name": "hotspot2005name",
+        "type": "text"
+      },
+      {
+        "display_name": "hotspot2004name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "HOTSPOT2004NAME",
+        "sql_name": "hotspot2004name",
+        "type": "text"
+      },
+      {
+        "display_name": "businessimprovementdistrict",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "BUSINESSIMPROVEMENTDISTRICT",
+        "sql_name": "businessimprovementdistrict",
+        "type": "text"
+      },
+      {
+        "display_name": "Unique data ID",
+        "display_text": "Identifies which source file this record came from",
+        "required_in_source": false,
+        "source_name": "unique_data_id",
+        "sql_name": "unique_data_id",
+        "type": "text"
+      }
+    ],
+    "replace_table": true
+  },
+  "dc_tax": {
+    "cleaner": "DCTaxCleaner",
+    "fields": [
+      {
+        "display_name": "objectid",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OBJECTID",
+        "sql_name": "objectid",
+        "type": "text"
+      },
+      {
+        "display_name": "ssl",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SSL",
+        "sql_name": "ssl",
+        "type": "text"
+      },
+      {
+        "display_name": "assessor_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ASSESSOR_NAME",
+        "sql_name": "assessor_name",
+        "type": "text"
+      },
+      {
+        "display_name": "land_use_code",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LAND_USE_CODE",
+        "sql_name": "land_use_code",
+        "type": "text"
+      },
+      {
+        "display_name": "land_use_description",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LAND_USE_DESCRIPTION",
+        "sql_name": "land_use_description",
+        "type": "text"
+      },
+      {
+        "display_name": "landarea",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LANDAREA",
+        "sql_name": "landarea",
+        "type": "integer"
+      },
+      {
+        "display_name": "property_address",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PROPERTY_ADDRESS",
+        "sql_name": "property_address",
+        "type": "text"
+      },
+      {
+        "display_name": "otr_neighborhood_code",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OTR_NEIGHBORHOOD_CODE",
+        "sql_name": "otr_neighborhood_code",
+        "type": "text"
+      },
+      {
+        "display_name": "otr_neighborhood_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OTR_NEIGHBORHOOD_NAME",
+        "sql_name": "otr_neighborhood_name",
+        "type": "text"
+      },
+      {
+        "display_name": "owner_name_primary",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OWNER_NAME_PRIMARY",
+        "sql_name": "owner_name_primary",
+        "type": "text"
+      },
+      {
+        "display_name": "careof_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CAREOF_NAME",
+        "sql_name": "careof_name",
+        "type": "text"
+      },
+      {
+        "display_name": "owner_address_line1",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OWNER_ADDRESS_LINE1",
+        "sql_name": "owner_address_line1",
+        "type": "text"
+      },
+      {
+        "display_name": "owner_address_line2",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OWNER_ADDRESS_LINE2",
+        "sql_name": "owner_address_line2",
+        "type": "text"
+      },
+      {
+        "display_name": "owner_address_citystzip",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OWNER_ADDRESS_CITYSTZIP",
+        "sql_name": "owner_address_citystzip",
+        "type": "text"
+      },
+      {
+        "display_name": "appraised_value_baseyear_land",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPRAISED_VALUE_BASEYEAR_LAND",
+        "sql_name": "appraised_value_baseyear_land",
+        "type": "integer"
+      },
+      {
+        "display_name": "appraised_value_baseyear_bldg",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPRAISED_VALUE_BASEYEAR_BLDG",
+        "sql_name": "appraised_value_baseyear_bldg",
+        "type": "integer"
+      },
+      {
+        "display_name": "appraised_value_prior_land",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPRAISED_VALUE_PRIOR_LAND",
+        "sql_name": "appraised_value_prior_land",
+        "type": "integer"
+      },
+      {
+        "display_name": "appraised_value_prior_impr",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPRAISED_VALUE_PRIOR_IMPR",
+        "sql_name": "appraised_value_prior_impr",
+        "type": "integer"
+      },
+      {
+        "display_name": "appraised_value_prior_total",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPRAISED_VALUE_PRIOR_TOTAL",
+        "sql_name": "appraised_value_prior_total",
+        "type": "integer"
+      },
+      {
+        "display_name": "appraised_value_current_land",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPRAISED_VALUE_CURRENT_LAND",
+        "sql_name": "appraised_value_current_land",
+        "type": "integer"
+      },
+      {
+        "display_name": "appraised_value_current_impr",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPRAISED_VALUE_CURRENT_IMPR",
+        "sql_name": "appraised_value_current_impr",
+        "type": "integer"
+      },
+      {
+        "display_name": "appraised_value_current_total",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "APPRAISED_VALUE_CURRENT_TOTAL",
+        "sql_name": "appraised_value_current_total",
+        "type": "integer"
+      },
+      {
+        "display_name": "phasein_value_current_land",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PHASEIN_VALUE_CURRENT_LAND",
+        "sql_name": "phasein_value_current_land",
+        "type": "integer"
+      },
+      {
+        "display_name": "phasein_value_current_bldg",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PHASEIN_VALUE_CURRENT_BLDG",
+        "sql_name": "phasein_value_current_bldg",
+        "type": "integer"
+      },
+      {
+        "display_name": "vacant_use",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "VACANT_USE",
+        "sql_name": "vacant_use",
+        "type": "boolean"
+      },
+      {
+        "display_name": "homestead_description",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "HOMESTEAD_DESCRIPTION",
+        "sql_name": "homestead_description",
+        "type": "text"
+      },
+      {
+        "display_name": "tax_type_description",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "TAX_TYPE_DESCRIPTION",
+        "sql_name": "tax_type_description",
+        "type": "text"
+      },
+      {
+        "display_name": "taxrate",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "TAXRATE",
+        "sql_name": "taxrate",
+        "type": "decimal"
+      },
+      {
+        "display_name": "mixed_use",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "MIXED_USE",
+        "sql_name": "mixed_use",
+        "type": "text"
+      },
+      {
+        "display_name": "owner_occupied_coop_units",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OWNER_OCCUPIED_COOP_UNITS",
+        "sql_name": "owner_occupied_coop_units",
+        "type": "integer"
+      },
+      {
+        "display_name": "last_sale_price",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LAST_SALE_PRICE",
+        "sql_name": "last_sale_price",
+        "type": "integer"
+      },
+      {
+        "display_name": "last_sale_date",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LAST_SALE_DATE",
+        "sql_name": "last_sale_date",
+        "type": "timestamp"
+      },
+      {
+        "display_name": "deed_date",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "DEED_DATE",
+        "sql_name": "deed_date",
+        "type": "timestamp"
+      },
+      {
+        "display_name": "current_assessment_cap",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CURRENT_ASSESSMENT_CAP",
+        "sql_name": "current_assessment_cap",
+        "type": "integer"
+      },
+      {
+        "display_name": "proposed_assessment_cap",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PROPOSED_ASSESSMENT_CAP",
+        "sql_name": "proposed_assessment_cap",
+        "type": "integer"
+      },
+      {
+        "display_name": "owner_name_secondary",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OWNER_NAME_SECONDARY",
+        "sql_name": "owner_name_secondary",
+        "type": "text"
+      },
+      {
+        "display_name": "address_id",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ADDRESS_ID",
+        "sql_name": "address_id",
+        "type": "text"
+      },
+      {
+        "display_name": "lastmodifieddate",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LASTMODIFIEDDATE",
+        "sql_name": "lastmodifieddate",
+        "type": "date"
+      },
+      {
+        "display_name": "Unique data ID",
+        "display_text": "Identifies which source file this record came from",
+        "required_in_source": false,
+        "source_name": "unique_data_id",
+        "sql_name": "unique_data_id",
+        "type": "text"
+      }
+    ],
+    "replace_table": true
+  }
+}


### PR DESCRIPTION
Modified `DataReader` class to handle byte order marks (BOMs) in data file headers, currently only found in opendata.dc.gov-sourced files (actually served from opendata.arcgis.com).  Ran tests on the dc_tax and building_permits data files.  (Ref: [Issue #133 comment](https://github.com/codefordc/housing-insights/issues/133#issuecomment-299519507))

After this merge, all opendata.dc.gov data files with BOMs no longer need to have the byte order mark manually stripped before uploading to the AWS S3 bucket.

Ref changes in `DataReader` class:

[Modifications to `download_data_file(...)`](https://github.com/dogtoothdigital/housing-insights/blob/dev/python/housinginsights/ingestion/DataReader.py#L198-L213)

[Addition of `_remove_bom_from_file(...)` and `_contains_leading_bom(...)`](https://github.com/dogtoothdigital/housing-insights/blob/dev/python/housinginsights/ingestion/DataReader.py#L294-L321)

-meg