### PR TITLE
Add sandbox Dockerfile for running python code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,10 @@ services:
         ports:
             - "5432:5432"
         restart: "on-failure:3"
+
+    sandbox:
+        build:
+            context: python
+        volumes:
+            - .:/code
+        command: tail -f /dev/null

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,3 +1,17 @@
-FROM python:3.5-onbuild
-COPY . /
-LABEL maintainer "NealHumphrey"
+FROM continuumio/miniconda3
+
+MAINTAINER Jason Haas <jasonrhaas@gmail.com>
+
+# Set up code directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Copy over files
+COPY environment.yml .
+COPY requirements.txt .
+
+# Install dependencies
+RUN conda env create
+
+# Activate environment
+RUN echo "export PATH=/opt/conda/envs/housing-insights/bin:$PATH" >> /root/.bashrc


### PR DESCRIPTION
## What's new

This fixes issue #183.  I added a new Dockerfile that has a pre-built environment for running all of our Python code.  Now we can run the python code inside this container without installing Miniconda locally.  This should make it easier to get our code up and running quickly.

## Testing it out

In the `housing-insights` directory, 
- In your **secrets.json** file, change the `docker_database` string to work inside the docker container. 
```
    "docker_database": {
        "_comments": "You may need to change the IP address and/or port for your machine.",
        "connect_str": "postgresql://codefordc:codefordc@postgres:5432/housinginsights_docker"
    },
```

- `docker-compose up -d`.  This will bring up all the containers including the `sandbox` which is the miniconda3 python container.
- `docker-compose exec sandbox bash` to get into the docker container
- `cd /code/python/scripts` to get into the script directory to load the data
- `python load_data.py docker rebuild sample` to load in the sample data

**NOTE**:  The data loading does not work at the moment due to some import errors.  This error is the same in the local environment and docker environment so it should not be an issue with the container.