### PR TITLE
Fixed db name to match secrets.json, switched wmata example with crim…

### DIFF
--- a/python/scripts/get_api_data.py
+++ b/python/scripts/get_api_data.py
@@ -63,10 +63,10 @@ def get_multiple_api_sources(unique_data_ids = None,sample=False, output_type = 
 
 if __name__ == '__main__':
     debug = True            #Errors are raised when they occur instead of only logged.
-    unique_data_ids = ['wmata_dist', 'wmata_stops']  #Alternatively, pass a list of only the data sources you want to download
+    unique_data_ids = ['crime_2016']  #Alternatively, pass a list of only the data sources you want to download
     sample = False          #Some ApiConn classes can just grab a sample of the data for use during development / testing
     output_type = 'csv'     #Other option is stdout which just prints to console
-    db = 'docker_with_local_python'  #Only used by connections that need to read from the database to get their job done (example: wmata)
+    db = 'docker_database'  #Only used by connections that need to read from the database to get their job done (example: wmata)
 
     get_multiple_api_sources(unique_data_ids,sample,output_type,db,debug)
 


### PR DESCRIPTION
…e as wmata example was broken

I wanted to get_api_data.py in a functioning state so folks can test with it if they want. I did add wmata key in secrets.json, this was the error I got with wmata_distcalc - 

```
$ python scripts/get_api_data.py 
  The unique_data_id 'wmata_dist' is not supported by the DCHousingApiConn
  The unique_data_id 'wmata_stops' is not supported by the DCHousingApiConn
  Connected to Housing Insights database
Starting new HTTPS connection (1): api.wmata.com
https://api.wmata.com:443 "GET /Rail.svc/json/jStations HTTP/1.1" 200 5997
  Processing project 0 of 360
  Starting processing rail stations for NL000001
Starting new HTTPS connection (1): api.mapbox.com
https://api.mapbox.com:443 "GET /directions/v5/mapbox/walking/-77.0221966,38.90811789;-77.028099,38.898303?access_token= HTTP/1.1" 401 39
The request for "wmata_distcalc" failed. Error: 'routes'
Traceback (most recent call last):
  File "scripts/get_api_data.py", line 71, in <module>
    get_multiple_api_sources(unique_data_ids,sample,output_type,db,debug)
  File "scripts/get_api_data.py", line 62, in get_multiple_api_sources
    raise e
  File "scripts/get_api_data.py", line 56, in get_multiple_api_sources
    api_method(unique_data_ids, sample, output_type, db=db)
  File "/home/ajhalani/work/housing-insights/python/housinginsights/sources/wmata_distcalc.py", line 43, in get_data
    self.get_dist(unique_data_ids=['wmata_dist'],sample=sample,output_type=output_type,db=db)
  File "/home/ajhalani/work/housing-insights/python/housinginsights/sources/wmata_distcalc.py", line 123, in get_dist
    self._find_rail_stations(self.railStations,project_details,radius,sample=sample)
  File "/home/ajhalani/work/housing-insights/python/housinginsights/sources/wmata_distcalc.py", line 269, in _find_rail_stations
    walkDist = self._get_walking_distance(lat, lon, str(station['Lat']), str(station['Lon']))
  File "/home/ajhalani/work/housing-insights/python/housinginsights/sources/wmata_distcalc.py", line 237, in _get_walking_distance
    return walkDistResponse.json()['routes'][0]['legs'][0]['distance']
KeyError: 'routes'

```