### PR TITLE
Jo connect charts to filters

### DIFF
--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -47,6 +47,7 @@ html, body {
     margin-top: 40px;  
     display: none;
     overflow-y: auto;
+    padding-top: 10px;
     
 }
 
@@ -55,6 +56,9 @@ html, body {
     flex-direction: column;
 }
 
+#buildings-list {
+    padding: 0 5px 0;
+}
 
 #left-options .sub-nav-button {
     border-right: 2px solid rgb(189, 54, 33);
@@ -172,7 +176,7 @@ html, body {
 
 #pie-charts {
     display: flex;
-    justify-content: space-between;
+    justify-content: space-around;
 }
 
 #zone-selector {

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -57,7 +57,8 @@ html, body {
 }
 
 #buildings-list {
-    padding: 0 5px 0;
+    
+    margin-top:105px;
 }
 
 #left-options .sub-nav-button {
@@ -177,6 +178,15 @@ html, body {
 #pie-charts {
     display: flex;
     justify-content: space-around;
+    position: fixed;
+    width: 100%;
+    box-shadow: 0 8px 17px #fff;
+    background-color: #fff;
+        top: 40px;
+    padding-top: 10px;
+}
+    
+
 }
 
 #zone-selector {

--- a/docs/tool/js/charts/chart-prototype.js
+++ b/docs/tool/js/charts/chart-prototype.js
@@ -8,6 +8,8 @@ var ChartProto = function(chartOptions) {    //chartOptions is an object, was DA
 ChartProto.prototype = {
     
     initialize: function(chartOptions) {
+      chartOptions.dataRequest.callback = chartCallback;  
+
       var chart = this; 
       this.field = chartOptions.field;
       this.width = chartOptions.width;
@@ -24,10 +26,10 @@ ChartProto.prototype = {
         .attr('text-anchor','middle');
         
        
-      chartOptions.dataRequest.callback = chartCallback;     
     
-      controller.getData(chartOptions.dataRequest) // dataRequest is an object {name:<String>, url: <String>[,callback:<Function>]]}
+      controller.getData(chartOptions.dataRequest); // dataRequest is an object {name:<String>, url: <String>[,callback:<Function>]]}
       function chartCallback(data){
+        console.log('chartProto callback',chart);
         chart.data = data.items;
         if (chartOptions.sort !== undefined ) {
           chart.data.sort(function(a, b) { 
@@ -36,14 +38,16 @@ ChartProto.prototype = {
           });            
         }
         chart.minValue = d3.min(chart.data, function(d) { 
-              return d[chartOptions.field]
+              if (chartOptions.field) return d[chartOptions.field];
+                return null;
         });
         chart.maxValue = d3.max(chart.data, function(d) { 
-              return d[chartOptions.field]
+              if (chartOptions.field) return d[chartOptions.field];
+              return null;
         });
-
+        console.log(chart.setupType);
         // The below 'if' block is necessary because SubsidyTimlineChart cannot access its own setupType function during the necessary ChartProto.call() call.
-        if (typeof chart.setupType === "function"){ chart.setupType(chartOptions); }
+        if (typeof chart.setupType === "function"){ console.log('calling setupType'); chart.setupType(chartOptions); }
       }
 
     },                       

--- a/docs/tool/js/charts/donut-chart-OLD.js
+++ b/docs/tool/js/charts/donut-chart-OLD.js
@@ -1,0 +1,133 @@
+"use strict";
+
+var DonutChart = function(chartOptions) { //
+    PieChartProto.call(this, chartOptions); 
+    this.extendPrototype(DonutChart.prototype, DonutChartExtension);
+}
+
+DonutChart.prototype = Object.create(PieChartProto.prototype);
+
+var DonutChartExtension = { 
+  returnPieVariable: function(field,zoneType,zoneName) {
+    var chart = this,
+    zoneIndex;
+    this.nested = d3.nest()    //aggregate data by unique values in [field] defined for each pie at bottom
+      .key(function(d) { return d[resultsView.zoneMapping[zoneType].name]; }) 
+      .key(function(d) { return d[field]; })
+      .rollup(function(v) { return v.length; })
+      .entries(chart.data);
+
+    var allObject = { // create object for sum of all zones
+        key:'All',
+        values: [
+            {
+                key: 'No',
+                value: 0
+            },
+            {
+                key: 'Yes',
+                value: 0
+            }
+        ]    
+    };
+
+    this.nested.forEach(function(obj){ // sum up the yeses and nos
+        obj.values.forEach(function(yesNo){
+            allObject.values.find(function(allValue){ 
+                return allValue.key === yesNo.key;
+            }).value += yesNo.value;
+        });
+    });
+    this.nested.sort(function(a,b){
+      return d3.ascending(a.key,b.key);
+    });
+    this.nested.push(allObject);
+    this.nested.move(-1,0); // uses array.prototype.move defined in housing-insights.js to move last item ("All") to be first.    
+   /* if ( zoneType !== currentZoneType ) {
+      setOptions(chart.nested);
+    }*/
+    zoneIndex = this.nested.findIndex(function(obj){ 
+        return obj.key === zoneName;
+    });
+    this.nested = this.checkForEmpties();
+    var stagePieVariable = this.nested[zoneIndex].values.sort(function(a,b){ // need to sort so that 'yes' is always in index 0
+        return d3.descending(a.key,b.key);
+    });
+    return this.addPercentYes(stagePieVariable);
+  },
+  addPercentYes: function(stagePieVariable){ // adds a third key/value to each chart's object for the percent yes
+                                             // now plotting only one arc bound to data, the percent yes, on top of
+                                             // static backdground. much of the preceding data manipulation is no longer
+                                             // necessary, but I'm leaving it in for now. It's more extensible, if we ever need
+                                             // to plot more than 2 variables in a pie. JO
+    var total = stagePieVariable[0].value + stagePieVariable[1].value;
+    var percentYes = stagePieVariable[0].value / total;
+    stagePieVariable.push({'key':'percentYes','value': percentYes});
+    return stagePieVariable;
+  },
+  checkForEmpties: function(){ // when the sum is zero, the nesting fails to create an object. this method
+                               // creates a dummy object such as {key:'Yes',value:0}
+        
+        this.nested.forEach(function(zone){
+            if ( zone.values.length < 2 ) {
+                var presentKey = zone.values[0].key;
+                var missingKey = presentKey === 'Yes' ? 'No' : 'Yes';
+                zone.values.push({key: missingKey, value: 0});
+            }
+        });
+       return this.nested; 
+  },  
+  setup: function(chartOptions){
+    
+    this.zoneType = chartOptions.zoneType;
+    this.zoneName = chartOptions.zoneName;
+    var chart = this;
+    
+    this.pieVariable = this.returnPieVariable(this.field, this.zoneType, this.zoneName); // order of yes and no objects in the array cannot be guaranteed, so JO is programmatically finding the index of yes
+    
+    
+
+    
+
+      // no longer need to invoke d3.pie because the angle of one arc is easy to calculate
+    /*chart.pie = d3.pie()
+        .sort(null)
+        .value(function(d) { return d.value; });
+    */
+    
+    chart.foreground = chart.svgCentered.append('path')
+      .style("fill", '#fd8d3c')
+      .datum({endAngle: 0});
+
+    chart.percentage = chart.svgCentered.append("text")
+        .attr("text-anchor", "middle")
+        .attr('class','pie_number')
+        .attr('y',5);
+
+     
+    if (chartOptions.index === 0){
+      setState('firstPieReady', true);
+    }
+    
+    this.update();
+  },
+  
+  returnTextPercent: function(){
+    var chart = this;    
+    var textPercent;
+        textPercent = d3.format(".0%")((chart.pieVariable[0].value)/(chart.pieVariable[1].value+chart.pieVariable[0].value));        
+    return textPercent;
+  },
+  update: function(){
+    var chart = this;
+    chart.foreground
+      .transition().duration(750)
+      .attrTween("d", chart.arcTween(chart.pieVariable[2].value * Math.PI * 2));
+    chart.percentage
+        .text(this.returnTextPercent());
+    chart.label 
+        .text(chart.field); // TODO: use meta.json to provide readable field names, or arrange for API to return them
+  }
+
+};
+

--- a/docs/tool/js/charts/donut-chart.js
+++ b/docs/tool/js/charts/donut-chart.js
@@ -1,99 +1,16 @@
 "use strict";
 
 var DonutChart = function(chartOptions) { //
-    PieChartProto.call(this, chartOptions); 
     this.extendPrototype(DonutChart.prototype, DonutChartExtension);
+    PieChartProto.call(this, chartOptions); 
 }
 
 DonutChart.prototype = Object.create(PieChartProto.prototype);
 
 var DonutChartExtension = { 
-  returnPieVariable: function(field,zoneType,zoneName) {
-    var chart = this,
-    zoneIndex;
-    this.nested = d3.nest()    //aggregate data by unique values in [field] defined for each pie at bottom
-      .key(function(d) { return d[resultsView.zoneMapping[zoneType].name]; }) 
-      .key(function(d) { return d[field]; })
-      .rollup(function(v) { return v.length; })
-      .entries(chart.data);
-
-    var allObject = { // create object for sum of all zones
-        key:'All',
-        values: [
-            {
-                key: 'No',
-                value: 0
-            },
-            {
-                key: 'Yes',
-                value: 0
-            }
-        ]    
-    };
-
-    this.nested.forEach(function(obj){ // sum up the yeses and nos
-        obj.values.forEach(function(yesNo){
-            allObject.values.find(function(allValue){ 
-                return allValue.key === yesNo.key;
-            }).value += yesNo.value;
-        });
-    });
-    this.nested.sort(function(a,b){
-      return d3.ascending(a.key,b.key);
-    });
-    this.nested.push(allObject);
-    this.nested.move(-1,0); // uses array.prototype.move defined in housing-insights.js to move last item ("All") to be first.    
-   /* if ( zoneType !== currentZoneType ) {
-      setOptions(chart.nested);
-    }*/
-    zoneIndex = this.nested.findIndex(function(obj){ 
-        return obj.key === zoneName;
-    });
-    this.nested = this.checkForEmpties();
-    var stagePieVariable = this.nested[zoneIndex].values.sort(function(a,b){ // need to sort so that 'yes' is always in index 0
-        return d3.descending(a.key,b.key);
-    });
-    return this.addPercentYes(stagePieVariable);
-  },
-  addPercentYes: function(stagePieVariable){ // adds a third key/value to each chart's object for the percent yes
-                                             // now plotting only one arc bound to data, the percent yes, on top of
-                                             // static backdground. much of the preceding data manipulation is no longer
-                                             // necessary, but I'm leaving it in for now. It's more extensible, if we ever need
-                                             // to plot more than 2 variables in a pie. JO
-    var total = stagePieVariable[0].value + stagePieVariable[1].value;
-    var percentYes = stagePieVariable[0].value / total;
-    stagePieVariable.push({'key':'percentYes','value': percentYes});
-    return stagePieVariable;
-  },
-  checkForEmpties: function(){ // when the sum is zero, the nesting fails to create an object. this method
-                               // creates a dummy object such as {key:'Yes',value:0}
-        
-        this.nested.forEach(function(zone){
-            if ( zone.values.length < 2 ) {
-                var presentKey = zone.values[0].key;
-                var missingKey = presentKey === 'Yes' ? 'No' : 'Yes';
-                zone.values.push({key: missingKey, value: 0});
-            }
-        });
-       return this.nested; 
-  },  
+  
   setup: function(chartOptions){
-    
-    this.zoneType = chartOptions.zoneType;
-    this.zoneName = chartOptions.zoneName;
-    var chart = this;
-    
-    this.pieVariable = this.returnPieVariable(this.field, this.zoneType, this.zoneName); // order of yes and no objects in the array cannot be guaranteed, so JO is programmatically finding the index of yes
-    
-    
-
-    
-
-      // no longer need to invoke d3.pie because the angle of one arc is easy to calculate
-    /*chart.pie = d3.pie()
-        .sort(null)
-        .value(function(d) { return d.value; });
-    */
+    var chart = this;    
     
     chart.foreground = chart.svgCentered.append('path')
       .style("fill", '#fd8d3c')
@@ -104,29 +21,24 @@ var DonutChartExtension = {
         .attr('class','pie_number')
         .attr('y',5);
 
-     
-    if (chartOptions.index === 0){
-      setState('firstPieReady', true);
-    }
-    
-    this.update();
+    //this.update();
   },
   
   returnTextPercent: function(){
-    var chart = this;    
+    /*var chart = this;    
     var textPercent;
         textPercent = d3.format(".0%")((chart.pieVariable[0].value)/(chart.pieVariable[1].value+chart.pieVariable[0].value));        
-    return textPercent;
+    return textPercent; */
   },
   update: function(){
-    var chart = this;
+  /*  var chart = this;
     chart.foreground
       .transition().duration(750)
       .attrTween("d", chart.arcTween(chart.pieVariable[2].value * Math.PI * 2));
     chart.percentage
         .text(this.returnTextPercent());
     chart.label 
-        .text(chart.field); // TODO: use meta.json to provide readable field names, or arrange for API to return them
+        .text(chart.field); // TODO: use meta.json to provide readable field names, or arrange for API to return them*/
   }
 
 };

--- a/docs/tool/js/charts/donut-chart.js
+++ b/docs/tool/js/charts/donut-chart.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var DonutChart = function(chartOptions) { //
+var DonutChart = function(chartOptions) { 
     this.extendPrototype(DonutChart.prototype, DonutChartExtension);
     PieChartProto.call(this, chartOptions); 
 }
@@ -10,27 +10,49 @@ DonutChart.prototype = Object.create(PieChartProto.prototype);
 var DonutChartExtension = { 
   
   setup: function(chartOptions){
-    var chart = this;    
+    
+    var chart = this;
+
+    this.countType = chartOptions.count; 
+
+    this.totalUnits = this.countTotalUnits();
+
     
     chart.foreground = chart.svgCentered.append('path')
       .style("fill", '#fd8d3c')
-      .datum({endAngle: 0});
+      .datum({endAngle: Math.PI});
 
     chart.percentage = chart.svgCentered.append("text")
         .attr("text-anchor", "middle")
         .attr('class','pie_number')
-        .attr('y',5);
+        .attr('y',5)
+        .text(d3.format(".0%")(1));
 
-    //this.update();
+    chart.label 
+        .text(chart.countType);
+
+    chart.foreground.transition().duration(750)
+      .attrTween("d", chart.arcTween(Math.PI * 2));
+
+    
   },
-  
+  countTotalUnits: function(){
+      var units = 0;
+      this.data.forEach(function(datum){
+        units += datum.proj_units_tot;
+      });
+      return units;
+  },
   returnTextPercent: function(){
     /*var chart = this;    
     var textPercent;
         textPercent = d3.format(".0%")((chart.pieVariable[0].value)/(chart.pieVariable[1].value+chart.pieVariable[0].value));        
     return textPercent; */
   },
-  update: function(){
+  updateSubscriber: function(msg,data){
+    resultsView.charts.forEach(function(chart){
+      DonutChart.prototype.update.call(chart,data);
+    })
   /*  var chart = this;
     chart.foreground
       .transition().duration(750)
@@ -39,6 +61,32 @@ var DonutChartExtension = {
         .text(this.returnTextPercent());
     chart.label 
         .text(chart.field); // TODO: use meta.json to provide readable field names, or arrange for API to return them*/
+  },
+  update: function(filterData){
+    var chart = this;
+    var factor;
+    if ( this.countType === 'Buildings' ) {
+      factor = filterData.length / this.data.length;
+    } else {
+      factor = returnUnitFactor();
+    }
+
+    this.foreground.transition().duration(750)
+      .attrTween("d", this.arcTween(factor * Math.PI * 2));
+
+    this.percentage
+      .text(d3.format(".0%")(factor));
+
+    function returnUnitFactor(){
+      var filteredProjects = chart.data.filter(function(datum){
+        return filterData.indexOf(datum.nlihc_id) !== -1;
+      });
+      var unitCounts = 0;
+      filteredProjects.forEach(function(project){
+        unitCounts += project.proj_units_tot;
+      });
+      return unitCounts / chart.totalUnits;
+    }
   }
 
 };

--- a/docs/tool/js/charts/pie-chart-proto.js
+++ b/docs/tool/js/charts/pie-chart-proto.js
@@ -1,8 +1,8 @@
 "use strict";
 
 var PieChartProto = function(chartOptions) { //
-    ChartProto.call(this, chartOptions); 
     this.extendPrototype(PieChartProto.prototype, PieProtoExtension);
+    ChartProto.call(this, chartOptions); 
 }
 
 PieChartProto.prototype = Object.create(ChartProto.prototype);
@@ -21,7 +21,7 @@ var PieProtoExtension = {
     this.arc = d3.arc()
       .outerRadius(chart.radius)
       .innerRadius(chart.radius - chart.width / 4)
-      .startAngle(0); // TODO set programmatically
+      .startAngle(0); 
     this.background = this.svgCentered  
         .append('path')
         .datum({endAngle: 2 * Math.PI})

--- a/docs/tool/js/core/housing-insights.js
+++ b/docs/tool/js/core/housing-insights.js
@@ -180,6 +180,7 @@ var controller = {
         } else {
             // TODO publish that data is available every time it's requested or only on first load?
             if ( dataRequest.callback !== undefined ) { // if callback has been passed in 
+                console.log(model.dataCollection[dataRequest.name]);
                 dataRequest.callback(model.dataCollection[dataRequest.name]);
             }              
         }

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -21,7 +21,7 @@ var mapView = {
                 ['mapLayer', mapView.showLayer],
                 ['mapLoaded', model.loadMetaData],
                 ['dataLoaded.metaData', mapView.addInitialLayers], //adds zone borders to geojson
-                ['filteredData', resultsView.init],
+                ['dataLoaded.metaData', resultsView.init],
                 ['dataLoaded.metaData', mapView.placeProjects],
                 ['dataLoaded.metaData', mapView.overlayMenu],
                 ['dataLoaded.raw_project', filterView.init],

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -32,7 +32,7 @@ var mapView = {
                 ['mapLayer', mapView.showLayer],
                 ['mapLoaded', model.loadMetaData],
                 ['dataLoaded.metaData', mapView.addInitialLayers],
-               //        ['dataLoaded.metaData', resultsView.init],
+                ['filteredData', resultsView.init],
                 ['dataLoaded.metaData', mapView.placeProjects],
                 ['dataLoaded.metaData', mapView.overlayMenu],
                 ['dataLoaded.raw_project', filterView.init],
@@ -365,7 +365,7 @@ var mapView = {
                 callback: dataCallback
             };
         controller.getData(dataRequest);
-        
+
         function dataCallback() {   
         console.log('in callback');     
             mapView.convertedProjects = controller.convertToGeoJSON(model.dataCollection.raw_project);

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -32,12 +32,12 @@ var mapView = {
                 ['mapLayer', mapView.showLayer],
                 ['mapLoaded', model.loadMetaData],
                 ['dataLoaded.metaData', mapView.addInitialLayers],
-                ['dataLoaded.metaData', resultsView.init],
+               //        ['dataLoaded.metaData', resultsView.init],
+                ['dataLoaded.metaData', mapView.placeProjects],
                 ['dataLoaded.metaData', mapView.overlayMenu],
-                ['dataLoaded.metaData', filterView.init],
+                ['dataLoaded.raw_project', filterView.init],
                 ['overlayRequest', mapView.addOverlayData],
                 ['joinedToGeo', mapView.addOverlayLayer],
-                ['dataLoaded.raw_project', mapView.placeProjects],
                 ['previewBuilding', mapView.showPopup],
                 ['filteredData', mapView.filterMap],
                 ['hoverBuildingList', mapView.highlightBuilding]
@@ -354,84 +354,96 @@ var mapView = {
             .attr('class','active');
 
     },
-    placeProjects: function(){ // some repetition here with the addLayer function used for zone layers. could be DRYer if combines
+    placeProjects: function(msg,data){ // some repetition here with the addLayer function used for zone layers. could be DRYer if combines
                                // or if used constructor with prototypical inheritance
-        mapView.convertedProjects = controller.convertToGeoJSON(model.dataCollection.raw_project);
-        mapView.convertedProjects.features.forEach(function(feature){
-            feature.properties.matches_filters = true;
-        });
-        mapView.listBuildings();
-        mapView.map.addSource('project', {
-          'type': 'geojson',
-          'data': mapView.convertedProjects
-        });
-        mapView.circleStrokeWidth =  1;
-        mapView.circleStrokeOpacity =  1;
-        mapView.map.addLayer({
-            'id': 'project',
-            'type': 'circle',
-            'source': 'project',
-            'paint': {
-                'circle-radius': {
-                    'base': 1.75,
-                    'stops': [[12, 3], [15, 32]]
-                }, 
-                'circle-opacity': 0.3,      
-                'circle-color': {
-                      property: 'category_code', // the field on which to base the color. this is probably not the category we want for v1
-                      type: 'categorical',
-                      stops: [ 
-                        ['1 - At-Risk or Flagged for Follow-up', '#f03b20'],
-                        ['2 - Expiring Subsidy', '#8B4225'],
-                        ['3 - Recent Failing REAC Score', '#bd0026'],
-                        ['4 - More Info Needed', '#A9A9A9'],
-                        ['5 - Other Subsidized Property', ' #fd8d3c'],
-                        ['6 - Lost Rental', '#A9A9A9']
-                      ]
-                },
-            'circle-stroke-width': mapView.circleStrokeWidth,
-            'circle-stroke-opacity': mapView.circleStrokeOpacity,
-            
-            'circle-stroke-color': {
-                property: 'category_code', 
-                      type: 'categorical',
-                      stops: [ 
-                        ['1 - At-Risk or Flagged for Follow-up', '#f03b20'],
-                        ['2 - Expiring Subsidy', '#8B4225'],
-                        ['3 - Recent Failing REAC Score', '#bd0026'],
-                        ['4 - More Info Needed', '#A9A9A9'],
-                        ['5 - Other Subsidized Property', ' #fd8d3c'],
-                        ['6 - Lost Rental', '#A9A9A9']
-                      ]
-                }
-            }
-        });
-       // TODO: MAKE LEGEND
-        mapView.map.on('mousemove', function(e) {
-             //get the province feature underneath the mouse
-             var features = mapView.map.queryRenderedFeatures(e.point, {
-                 layers: ['project']
-             });
-             //if there's a point under our mouse, then do the following.
-             if (features.length > 0) {
-                 //use the following code to change the 
-                 //cursor to a pointer ('pointer') instead of the default ('')
-                 mapView.map.getCanvas().style.cursor = (features[0].properties.proj_addre != null) ? 'pointer' : '';
-             }
-             //if there are no points under our mouse, 
-             //then change the cursor back to the default
-             else {
-                 mapView.map.getCanvas().style.cursor = '';
-             }
-        });
-        mapView.map.on('click', function (e) {
-            console.log(e);
-            var building = (mapView.map.queryRenderedFeatures(e.point, { layers: ['project'] }))[0];
-            console.log(building);
-            if ( building === undefined ) return;
-            setState('previewBuilding', building);
-           });               
+        console.log(msg,data);
+        var dataURLInfo = model.dataCollection.metaData.project.api;
+        var dataURL = dataURLInfo.raw_endpoint;
+        var dataRequest = {
+                name: 'raw_project',
+                url: dataURL, 
+                callback: dataCallback
+            };
+        controller.getData(dataRequest);
         
+        function dataCallback() {   
+        console.log('in callback');     
+            mapView.convertedProjects = controller.convertToGeoJSON(model.dataCollection.raw_project);
+            mapView.convertedProjects.features.forEach(function(feature){
+                feature.properties.matches_filters = true;
+            });
+            mapView.listBuildings();
+            mapView.map.addSource('project', {
+              'type': 'geojson',
+              'data': mapView.convertedProjects
+            });
+            mapView.circleStrokeWidth =  1;
+            mapView.circleStrokeOpacity =  1;
+            mapView.map.addLayer({
+                'id': 'project',
+                'type': 'circle',
+                'source': 'project',
+                'paint': {
+                    'circle-radius': {
+                        'base': 1.75,
+                        'stops': [[12, 3], [15, 32]]
+                    }, 
+                    'circle-opacity': 0.3,      
+                    'circle-color': {
+                          property: 'category_code', // the field on which to base the color. this is probably not the category we want for v1
+                          type: 'categorical',
+                          stops: [ 
+                            ['1 - At-Risk or Flagged for Follow-up', '#f03b20'],
+                            ['2 - Expiring Subsidy', '#8B4225'],
+                            ['3 - Recent Failing REAC Score', '#bd0026'],
+                            ['4 - More Info Needed', '#A9A9A9'],
+                            ['5 - Other Subsidized Property', ' #fd8d3c'],
+                            ['6 - Lost Rental', '#A9A9A9']
+                          ]
+                    },
+                'circle-stroke-width': mapView.circleStrokeWidth,
+                'circle-stroke-opacity': mapView.circleStrokeOpacity,
+                
+                'circle-stroke-color': {
+                    property: 'category_code', 
+                          type: 'categorical',
+                          stops: [ 
+                            ['1 - At-Risk or Flagged for Follow-up', '#f03b20'],
+                            ['2 - Expiring Subsidy', '#8B4225'],
+                            ['3 - Recent Failing REAC Score', '#bd0026'],
+                            ['4 - More Info Needed', '#A9A9A9'],
+                            ['5 - Other Subsidized Property', ' #fd8d3c'],
+                            ['6 - Lost Rental', '#A9A9A9']
+                          ]
+                    }
+                }
+            });
+           // TODO: MAKE LEGEND
+            mapView.map.on('mousemove', function(e) {
+                 //get the province feature underneath the mouse
+                 var features = mapView.map.queryRenderedFeatures(e.point, {
+                     layers: ['project']
+                 });
+                 //if there's a point under our mouse, then do the following.
+                 if (features.length > 0) {
+                     //use the following code to change the 
+                     //cursor to a pointer ('pointer') instead of the default ('')
+                     mapView.map.getCanvas().style.cursor = (features[0].properties.proj_addre != null) ? 'pointer' : '';
+                 }
+                 //if there are no points under our mouse, 
+                 //then change the cursor back to the default
+                 else {
+                     mapView.map.getCanvas().style.cursor = '';
+                 }
+            });
+            mapView.map.on('click', function (e) {
+                console.log(e);
+                var building = (mapView.map.queryRenderedFeatures(e.point, { layers: ['project'] }))[0];
+                console.log(building);
+                if ( building === undefined ) return;
+                setState('previewBuilding', building);
+               });               
+        } // end dataCallback
     },
     showPopup: function(msg,data){
 console.log(data);

--- a/docs/tool/js/views/results-view-OLD.js
+++ b/docs/tool/js/views/results-view-OLD.js
@@ -1,0 +1,99 @@
+"use strict";
+
+var resultsView = {
+    init: function() {
+        setSubs([
+          //  ['firstPieReady', resultsView.setDropdownOptions],
+            ['mapLayer',resultsView.changeZoneType],
+            ['pieZone', resultsView.changeZoneType]
+        ]);
+        resultsView.charts = [];
+        var instances = ['subsidized','cat_expiring','cat_failing_insp','cat_at_risk'];
+        instances.forEach(function(instance, i){
+            resultsView.charts[i] = new DonutChart({
+                dataRequest: {
+                    name: 'raw_project',
+                    url: model.dataCollection.metaData.project.api.raw_endpoint
+                },
+                field: instance,
+                container: '#pie-' + i,
+                width: 75,
+                height: 95,
+                zoneType: 'ward',
+                zoneName: 'All',
+                index: i,
+                margin: {
+                    top:0,
+                    right:0,
+                    bottom:20,
+                    left:0
+                }
+            })
+        });
+    },
+    zoneMapping: { // object to map mapLayer names (the keys) to the field in the data
+                  // later code adds an array of all the values for each type to the objects
+                  // for populating the dropdown list
+        ward: {
+          name: 'ward'
+          
+        },
+        tract: {
+          name: 'census_tract'
+          
+        },
+        zip: {
+          name: 'zip'
+        },
+        neighborhood_cluster: {
+          name: 'neighborhood_cluster_desc'
+        }
+    },
+  /*  setDropdownOptions: function() {
+               
+            var activeLayer = getState().mapLayer[0];            
+            if ( resultsView.zoneMapping[activeLayer].values === undefined ) { // i.e. the  zones withing the zoneType have not been 
+                                                                       // enumerated yet
+                resultsView.zoneMapping[activeLayer].values = [];
+                resultsView.charts[0].nested.forEach(function(obj) {
+                    resultsView.zoneMapping[activeLayer].values.push(obj.key)
+                });                                    
+            }
+            var selector = document.getElementById('zone-selector');
+            selector.onchange = function(e){
+                setState('pieZone', e.target.selectedOptions[0].value);                 
+            };
+            selector.innerHTML = '';
+            resultsView.zoneMapping[activeLayer].values.forEach(function(zone,i){
+                var option = document.createElement('option');
+                if ( i === 0 ) { option.setAttribute('selected','selected'); }
+                option.setAttribute('class',activeLayer);
+                option.setAttribute('value',zone);
+                option.id = zone.toLowerCase().replace(/ /g,'-');
+                option.innerHTML = zone;
+                selector.appendChild(option);
+            });
+
+    }, */
+    changeZoneType: function(msg){
+        var zoneType = getState().mapLayer[0];
+       
+        if (getState().firstPieReady) { 
+            if (msg === 'mapLayer') {
+                setState('pieZone', 'All');
+            }
+            var zoneName = getState().pieZone[0];                
+            resultsView.charts.forEach(function(chart){
+                chart.pieVariable = chart.returnPieVariable(chart.field,zoneType,zoneName);
+                chart.update();
+            });
+            if ( msg === 'mapLayer' ) { // if fn was called by changing mapLayer state. if not, leave dropdown
+                                        // menu alone
+           //     resultsView.setDropdownOptions();
+            }
+        } else { // if this function was called suring initial setup, before pies were ready
+            setState('pieZone', 'All');
+        }
+    }
+
+};

--- a/docs/tool/js/views/results-view.js
+++ b/docs/tool/js/views/results-view.js
@@ -3,7 +3,7 @@
 var resultsView = {
     init: function() {
         setSubs([
-            ['firstPieReady', resultsView.setDropdownOptions],
+          //  ['firstPieReady', resultsView.setDropdownOptions],
             ['mapLayer',resultsView.changeZoneType],
             ['pieZone', resultsView.changeZoneType]
         ]);
@@ -49,7 +49,7 @@ var resultsView = {
           name: 'neighborhood_cluster_desc'
         }
     },
-    setDropdownOptions: function() {
+  /*  setDropdownOptions: function() {
                
             var activeLayer = getState().mapLayer[0];            
             if ( resultsView.zoneMapping[activeLayer].values === undefined ) { // i.e. the  zones withing the zoneType have not been 
@@ -74,10 +74,10 @@ var resultsView = {
                 selector.appendChild(option);
             });
 
-    },
+    }, */
     changeZoneType: function(msg){
         var zoneType = getState().mapLayer[0];
-        document.getElementById('zone-drilldown-instructions').innerHTML = 'Choose a ' + zoneType;
+       
         if (getState().firstPieReady) { 
             if (msg === 'mapLayer') {
                 setState('pieZone', 'All');
@@ -89,7 +89,7 @@ var resultsView = {
             });
             if ( msg === 'mapLayer' ) { // if fn was called by changing mapLayer state. if not, leave dropdown
                                         // menu alone
-                resultsView.setDropdownOptions();
+           //     resultsView.setDropdownOptions();
             }
         } else { // if this function was called suring initial setup, before pies were ready
             setState('pieZone', 'All');

--- a/docs/tool/js/views/results-view.js
+++ b/docs/tool/js/views/results-view.js
@@ -8,11 +8,9 @@ var resultsView = {
         // changed Jun 8 to be called by filteredData
         
         console.log('resultsView.init()');
-        setSubs([
-          // filteredData should trigger an update
-        ]);
+        
         resultsView.charts = [];
-        var instances = ['buildings','units'];
+        var instances = ['Buildings','Units'];
         instances.forEach(function(instance, i){
             resultsView.charts[i] = new DonutChart({
                 dataRequest: {
@@ -32,6 +30,9 @@ var resultsView = {
                     left:0
                 }
             })
-        });        
+        });
+        setSubs([
+          ['filteredData', DonutChart.prototype.updateSubscriber]
+        ]);        
     }
 };

--- a/docs/tool/js/views/results-view.js
+++ b/docs/tool/js/views/results-view.js
@@ -2,25 +2,23 @@
 
 var resultsView = {
     init: function() {
+        console.log('resultsView.init()');
         setSubs([
-          //  ['firstPieReady', resultsView.setDropdownOptions],
-            ['mapLayer',resultsView.changeZoneType],
-            ['pieZone', resultsView.changeZoneType]
+          // filteredData should trigger an update
         ]);
         resultsView.charts = [];
-        var instances = ['subsidized','cat_expiring','cat_failing_insp','cat_at_risk'];
+        var instances = ['buildings','units'];
         instances.forEach(function(instance, i){
             resultsView.charts[i] = new DonutChart({
                 dataRequest: {
                     name: 'raw_project',
                     url: model.dataCollection.metaData.project.api.raw_endpoint
                 },
-                field: instance,
+
+                count: instance,
                 container: '#pie-' + i,
                 width: 75,
                 height: 95,
-                zoneType: 'ward',
-                zoneName: 'All',
                 index: i,
                 margin: {
                     top:0,
@@ -30,70 +28,6 @@ var resultsView = {
                 }
             })
         });
-    },
-    zoneMapping: { // object to map mapLayer names (the keys) to the field in the data
-                  // later code adds an array of all the values for each type to the objects
-                  // for populating the dropdown list
-        ward: {
-          name: 'ward'
-          
-        },
-        tract: {
-          name: 'census_tract'
-          
-        },
-        zip: {
-          name: 'zip'
-        },
-        neighborhood_cluster: {
-          name: 'neighborhood_cluster_desc'
-        }
-    },
-  /*  setDropdownOptions: function() {
-               
-            var activeLayer = getState().mapLayer[0];            
-            if ( resultsView.zoneMapping[activeLayer].values === undefined ) { // i.e. the  zones withing the zoneType have not been 
-                                                                       // enumerated yet
-                resultsView.zoneMapping[activeLayer].values = [];
-                resultsView.charts[0].nested.forEach(function(obj) {
-                    resultsView.zoneMapping[activeLayer].values.push(obj.key)
-                });                                    
-            }
-            var selector = document.getElementById('zone-selector');
-            selector.onchange = function(e){
-                setState('pieZone', e.target.selectedOptions[0].value);                 
-            };
-            selector.innerHTML = '';
-            resultsView.zoneMapping[activeLayer].values.forEach(function(zone,i){
-                var option = document.createElement('option');
-                if ( i === 0 ) { option.setAttribute('selected','selected'); }
-                option.setAttribute('class',activeLayer);
-                option.setAttribute('value',zone);
-                option.id = zone.toLowerCase().replace(/ /g,'-');
-                option.innerHTML = zone;
-                selector.appendChild(option);
-            });
-
-    }, */
-    changeZoneType: function(msg){
-        var zoneType = getState().mapLayer[0];
-       
-        if (getState().firstPieReady) { 
-            if (msg === 'mapLayer') {
-                setState('pieZone', 'All');
-            }
-            var zoneName = getState().pieZone[0];                
-            resultsView.charts.forEach(function(chart){
-                chart.pieVariable = chart.returnPieVariable(chart.field,zoneType,zoneName);
-                chart.update();
-            });
-            if ( msg === 'mapLayer' ) { // if fn was called by changing mapLayer state. if not, leave dropdown
-                                        // menu alone
-           //     resultsView.setDropdownOptions();
-            }
-        } else { // if this function was called suring initial setup, before pies were ready
-            setState('pieZone', 'All');
-        }
     }
 
 };

--- a/docs/tool/partials/map-view.html
+++ b/docs/tool/partials/map-view.html
@@ -6,7 +6,7 @@
         </div>
         <div id="options-spacer"></div>
         <div id="right-options">
-            <button class="sub-nav-button" id="button-charts">Charts</button>
+            <!--<button class="sub-nav-button" id="button-charts">Charts</button>-->
             <button class="sub-nav-button" id="button-buildings">Buildings <span id="matching-count"></span></button>
         </div>
     </div>
@@ -37,18 +37,21 @@
 
                 <div class="sub-nav-group">                    
                     
-                    <div id="pie-charts">
-                        <div id="pie-0"></div>
-                        <div id="pie-1"></div>                       
-                    </div>                        
+                                          
                 </div>
 
             </div>
             <div id="buildings" class="sub-nav-container">
                 <div class="sub-nav-group">
-                   
-                    <div id="buildings-list">
-                       
+                    
+                        <div id="pie-charts">
+                            <div id="pie-0"></div>
+                            <div id="pie-1"></div>                       
+                        </div>  
+                    
+                </div>
+                <div class="sub-nav-group">                   
+                    <div id="buildings-list">                       
                     </div>
                 </div>
             </div>

--- a/docs/tool/partials/map-view.html
+++ b/docs/tool/partials/map-view.html
@@ -30,21 +30,15 @@
         <sidebar id="sidebar">
             
             <div id="charts" class="sub-nav-container">
-                <div id="stats">
-                    <h2>Affordable building statistics</h2>
-                    <div id="stats-inner">
-                        <p>Select a zone type on the left to change drilldown options</p>
-                        <p id="zone-drilldown-instructions">Choose a ward</p>
-                        <select id="zone-selector" role="group" aria-label="Filter">
-                        </select>
+                
+                        
                         <div id="pie-charts">
                             <div id="pie-0"></div>
                             <div id="pie-1"></div>
                             <div id="pie-2"></div>
                             <div id="pie-3"></div>
                         </div>
-                    </div>
-                </div>
+                    
             </div>
             <div id="buildings" class="sub-nav-container">
                 <h2></h2>

--- a/docs/tool/partials/map-view.html
+++ b/docs/tool/partials/map-view.html
@@ -39,9 +39,7 @@
                     
                     <div id="pie-charts">
                         <div id="pie-0"></div>
-                        <div id="pie-1"></div>
-                        <div id="pie-2"></div>
-                        <div id="pie-3"></div>
+                        <div id="pie-1"></div>                       
                     </div>                        
                 </div>
 


### PR DESCRIPTION
— Two donut charts instead of four
— Connected to filterData event
— First shows percentage of buildings matching the filter(s)
— Second shows the percentage of total units represented by the buildings matching the filter(s)

The last commit puts the charts in the buildings pane and removes the charts pane. With only two charts, it seems unnecessary to have a separate pane for them. And these charts work really well here, animating their change at the same time the list is shortened or lengthened.

If you prefer keeping the charts pain, revert to the second to last commit.