### PR TITLE
Ready: Adding documentation for OpenData sources

### DIFF
--- a/docs/data/building_permits.md
+++ b/docs/data/building_permits.md
@@ -1,0 +1,14 @@
+---
+---
+layout: datasource
+tablename: building_permits
+title: Building Permit Data
+---
+
+The DC Department of Consumer and Regulatory Affairs has made this data available. This dataset contains records of building construction and alteration permits.
+
+This data is released on an annual basis - we display data from 2013-2017. The latest data for 2017 (partial) can be found at [OpenData DC](http://opendata.dc.gov/datasets/building-permits-in-2017).
+
+Basic cleaning was performed on this data, including replacement of null values and normalization of dates and census tract/ward names.
+
+This data source is used with permission from [OpenData DC]({{site.baseurl}}/opendata).

--- a/docs/data/building_permits.md
+++ b/docs/data/building_permits.md
@@ -1,5 +1,4 @@
 ---
----
 layout: datasource
 tablename: building_permits
 title: Building Permit Data
@@ -11,4 +10,4 @@ This data is released on an annual basis - we display data from 2013-2017. The l
 
 Basic cleaning was performed on this data, including replacement of null values and normalization of dates and census tract/ward names.
 
-This data source is used with permission from [OpenData DC]({{site.baseurl}}/opendata).
+This data source is used with permission from [OpenData DC]({{site.baseurl}}/data/opendata).

--- a/docs/data/crime.md
+++ b/docs/data/crime.md
@@ -1,0 +1,14 @@
+---
+---
+layout: datasource
+tablename: crime
+title: Crime Data
+---
+
+The DC Metropolitan Police have made this data available through their Crime Map service.  This dataset contains incidents of crime reported to the police.
+
+This data is released on an annual basis - we display data from 2015-2017. The latest data for 2017 can be found at [OpenData DC](http://opendata.dc.gov/datasets/crime-incidents-in-2017).
+
+Basic cleaning was performed on this data, including replacement of null values and normalization of dates and census tract/ward names.
+
+This data source is used with permission from [OpenData DC]({{site.baseurl}}/opendata).

--- a/docs/data/crime.md
+++ b/docs/data/crime.md
@@ -1,5 +1,4 @@
 ---
----
 layout: datasource
 tablename: crime
 title: Crime Data

--- a/docs/data/opendata.md
+++ b/docs/data/opendata.md
@@ -1,0 +1,19 @@
+---
+---
+layout: datasource
+tablename: example_table_name
+title: Example Table
+---
+<!--No need to put a header; the title in the front matter (above) will be used as a header-->
+
+A number of data sources come from the [opendata.dc.gov](http://opendata.dc.gov/) project. The OpenData project describes itself as a site where:
+
+> ...the District of Columbia government shares hundreds of datasets. DC realizes that data’s greatest value comes from having it freely shared among agencies, federal and regional governments and with the public to the extent possible when considering safety, privacy and security. 
+
+Users are invited to analyze the available datasets and build apps using OpenData's APIs.
+
+We have used the following data sources from OpenData. Please click the links below to read about each source in further detail.
+
+[Building Permits]({{site.baseurl}}/building_permits)
+[Crime]({{site.baseurl}}/crime)
+[Tax]({{site.baseurl}}/tax)

--- a/docs/data/opendata.md
+++ b/docs/data/opendata.md
@@ -1,19 +1,20 @@
 ---
----
 layout: datasource
-tablename: example_table_name
-title: Example Table
+tablename: N/A
+title: Open Data DC
 ---
 <!--No need to put a header; the title in the front matter (above) will be used as a header-->
 
 A number of data sources come from the [opendata.dc.gov](http://opendata.dc.gov/) project. The OpenData project describes itself as a site where:
 
-> ...the District of Columbia government shares hundreds of datasets. DC realizes that data’s greatest value comes from having it freely shared among agencies, federal and regional governments and with the public to the extent possible when considering safety, privacy and security. 
+> ...the District of Columbia government shares hundreds of datasets. DC realizes that data’s greatest value comes from having it freely shared among agencies, federal and regional governments and with the public to the extent possible when considering safety, privacy and security.
 
 Users are invited to analyze the available datasets and build apps using OpenData's APIs.
 
 We have used the following data sources from OpenData. Please click the links below to read about each source in further detail.
 
-[Building Permits]({{site.baseurl}}/building_permits)
-[Crime]({{site.baseurl}}/crime)
-[Tax]({{site.baseurl}}/tax)
+* [Building Permits]({{site.baseurl}}/data/building_permits)
+
+* [Crime]({{site.baseurl}}/data/crime)
+
+* [Tax]({{site.baseurl}}/data/tax)

--- a/docs/data/tax.md
+++ b/docs/data/tax.md
@@ -1,0 +1,14 @@
+---
+---
+layout: datasource
+tablename: dc_tax
+title: DC Tax Data
+---
+
+This is the public extract of the database used for sending tax bills, also known as tax assessment roll.  ITS stores comprehensive tax information such as ownership, mailing addresses etc of record lots, tax lots, parcels, condominiums and federally owned lands such as reservations and appropriations. This dataset is owned and maintained by the DC Office of Tax and Revenue.
+
+This data is released on an annual basis - we display data from 2017. The latest data can be found at [OpenData DC](https://opendata.arcgis.com/datasets/DCGIS::integrated-tax-system-public-extract).
+
+Basic cleaning was performed on this data, including replacement of null values and normalization of dates.
+
+This data source is used with permission from [OpenData DC]({{site.baseurl}}/opendata).

--- a/docs/data/tax.md
+++ b/docs/data/tax.md
@@ -1,5 +1,4 @@
 ---
----
 layout: datasource
 tablename: dc_tax
 title: DC Tax Data
@@ -11,4 +10,4 @@ This data is released on an annual basis - we display data from 2017. The latest
 
 Basic cleaning was performed on this data, including replacement of null values and normalization of dates.
 
-This data source is used with permission from [OpenData DC]({{site.baseurl}}/opendata).
+This data source is used with permission from [OpenData DC]({{site.baseurl}}/data/opendata).


### PR DESCRIPTION
This PR contains new documentation for several data sources (all from DC OpenData) as part of the effort led by @emkap01.

OpenData.md has general information on the DC OpenData initiative, and each source has its own .md file that links back to it. I'm new to the way internal markdown links work, so I am hopeful that I did them correctly.

Hope this is helpful! Happy to expand further as needed.