### PR TITLE
344 add layers to view

### DIFF
--- a/docs/tool/js/core/housing-insights.js
+++ b/docs/tool/js/core/housing-insights.js
@@ -289,8 +289,11 @@ var setSubs = controller.controlSubs.setSubs,
     cancelFunction = controller.controlSubs.cancelFunction;
 
 /*
- * POLYFILLS AND HELPERS ***********************
+ * HELPERS *********************** (polyfills moved to separate file to be more explicit)
  */
+
+ //TODO should these be wrapped up into a 'helpers' namespace? Or maybe the new utils section?
+
 
  // HELPER get parameter by name
  var getParameterByName = function(name, url) { // HT http://stackoverflow.com/a/901144/5701184
@@ -345,52 +348,6 @@ String.prototype.cleanString = function() { // lowercase and remove punctuation 
     return this.replace(/[ \\\/]/g,'-').replace(/['"”’“‘,\.!\?;\(\)&]/g,'').toLowerCase();
 };
 
-// Polyfill for Array.findIndex()
-
-// https://tc39.github.io/ecma262/#sec-array.prototype.findIndex
-if (!Array.prototype.findIndex) {
-  Object.defineProperty(Array.prototype, 'findIndex', {
-    value: function(predicate) {
-     // 1. Let O be ? ToObject(this value).
-      if (this == null) {
-        throw new TypeError('"this" is null or not defined');
-      }
-
-      var o = Object(this);
-
-      // 2. Let len be ? ToLength(? Get(O, "length")).
-      var len = o.length >>> 0;
-
-      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
-      if (typeof predicate !== 'function') {
-        throw new TypeError('predicate must be a function');
-      }
-
-      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-      var thisArg = arguments[1];
-
-      // 5. Let k be 0.
-      var k = 0;
-
-      // 6. Repeat, while k < len
-      while (k < len) {
-        // a. Let Pk be ! ToString(k).
-        // b. Let kValue be ? Get(O, Pk).
-        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-        // d. If testResult is true, return k.
-        var kValue = o[k];
-        if (predicate.call(thisArg, kValue, k, o)) {
-          return k;
-        }
-        // e. Increase k by 1.
-        k++;
-      }
-
-      // 7. Return -1.
-      return -1;
-    }
-  });
-}
 
 /* Go! */
 

--- a/docs/tool/js/util/polyfills.js
+++ b/docs/tool/js/util/polyfills.js
@@ -102,3 +102,50 @@ if (!Array.prototype.includes) {
     }
   });
 }
+
+// Polyfill for Array.findIndex()
+
+// https://tc39.github.io/ecma262/#sec-array.prototype.findIndex
+if (!Array.prototype.findIndex) {
+  Object.defineProperty(Array.prototype, 'findIndex', {
+    value: function(predicate) {
+     // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return k.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return k;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return -1.
+      return -1;
+    }
+  });
+}

--- a/docs/tool/js/util/polyfills.js
+++ b/docs/tool/js/util/polyfills.js
@@ -46,3 +46,59 @@ if (!Array.prototype.find) {
     }
   });
 }
+
+
+
+
+
+// https://tc39.github.io/ecma262/#sec-array.prototype.includes
+if (!Array.prototype.includes) {
+  Object.defineProperty(Array.prototype, 'includes', {
+    value: function(searchElement, fromIndex) {
+
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If len is 0, return false.
+      if (len === 0) {
+        return false;
+      }
+
+      // 4. Let n be ? ToInteger(fromIndex).
+      //    (If fromIndex is undefined, this step produces the value 0.)
+      var n = fromIndex | 0;
+
+      // 5. If n ≥ 0, then
+      //  a. Let k be n.
+      // 6. Else n < 0,
+      //  a. Let k be len + n.
+      //  b. If k < 0, let k be 0.
+      var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+      function sameValueZero(x, y) {
+        return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+      }
+
+      // 7. Repeat, while k < len
+      while (k < len) {
+        // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+        // b. If SameValueZero(searchElement, elementK) is true, return true.
+        // c. Increase k by 1. 
+        if (sameValueZero(o[k], searchElement)) {
+          return true;
+        }
+        k++;
+      }
+
+      // 8. Return false
+      return false;
+    }
+  });
+}

--- a/docs/tool/js/views/chloropleth-legend.js
+++ b/docs/tool/js/views/chloropleth-legend.js
@@ -2,9 +2,9 @@
 
 var chloroplethLegend = {
   init: function(message,data){
-
     var joinedToGeoName = "joinedToGeo." + data.overlay + "_" + data.activeLayer;
     var chloroplethRange = getState()[joinedToGeoName][0].chloroplethRange;
+    var overlayConfig = mapView.initialOverlays.find(function(obj){return obj['name']==data.overlay});
 
     chloroplethLegend.tearDownPrevious();
 
@@ -28,13 +28,25 @@ var chloroplethLegend = {
 
     function partialCallback(){
 
-      // Copied shamelessly from:
-      // https://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript
       // This probably belongs at a broader scope, though currently
       // is only used below.
-      function numberWithCommas(x) {
-        return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      function formatNumber(x,style) {
+        if (style=="number") {
+          x = Math.round(x)
+          return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","); //adds thousands separators, from https://stackoverflow.com/questions/2901102/how-to-print-a-number-with-commas-as-thousands-separators-in-javascript
+        }
+        if (style == "percent") {
+          x = Math.round(x * 100) + "%"
+          return x
+        }
+        if (style == "money"){
+          x = Math.round(x)
+          x = x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","); //adds thousands separators
+          x = "$" + x
+          return x
+        }
       }
+
 
       var eachLegendItem = d3.select('#chloroplethLegend ul')
                               .selectAll('li')
@@ -48,9 +60,16 @@ var chloroplethLegend = {
                     });
       eachLegendItem.append('span')
                     .text(function(d, i){
-                      var ary = chloroplethRange.stopsAscending;
-                      var stopMax = (i === ary.length - 1 ? "" : " - " + (+ary[i+1][0] - 1));
-                      return numberWithCommas(d[0]) + numberWithCommas(stopMax);
+                        var ary = chloroplethRange.stopsAscending;
+                        var stopMax = (i === ary.length - 1 ? null : (+ary[i+1][0]  )); //removed subtract 1 because doesn't work w/ percents. TODO should fix this to provide a logical "less than but not equal to" display!
+                        var style = overlayConfig['style']
+
+                        if (stopMax !== null) {
+                            var descriptor = formatNumber(d[0],style) + " - " + formatNumber(stopMax,style);
+                        } else {
+                            var descriptor = formatNumber(d[0],style) 
+                        };
+                      return descriptor
                     });
     }
   

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -145,24 +145,6 @@ var filterView = {
 
         oldPills.exit().remove();
 
-
-
-        /*
-        this.trigger = document.createElement('i');
-        this.trigger.id = 'clearFiltersTrigger';
-        this.trigger.classList.add('delete', 'icon');
-
-        this.site.innerText = "";
-
-        this.pill.innerText = this.replacedText;
-
-        this.site.appendChild(this.pill);
-        this.pill.appendChild(this.trigger);
-        
-        this.trigger.addEventListener('click', function(){
-            filterView.clearAllFilters();
-        });
-        */
     },
 
     init: function(msg, data) {

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -147,7 +147,8 @@
                     display_text: "Number of violent crime incidents per 100,000 people reported in the past 12 months.",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/rate/crime/violent/12/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "ward"
+                    default_layer: "ward",
+                    style: "number"
                 },
                 {
                     name: "crime_nonviolent_12",
@@ -155,7 +156,8 @@
                     display_text: "Number of non-violent crime incidents per 100,000 people reported in this zone in the past 12 months.",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/rate/crime/nonviolent/12/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "ward"
+                    default_layer: "ward",
+                    style: "number"
                 },
                 {
                     name: "crime_all_3",
@@ -163,7 +165,8 @@
                     display_text: "Total number of crime incidents per 100,000 people reported in the past 12 months.",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/rate/crime/all/3/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "ward"
+                    default_layer: "ward",
+                    style: "number"
                 },
                 {
                     name: "building_permits_construction",
@@ -171,7 +174,8 @@
                     display_text: "Number of construction building permits issued in the zone during 2016. (2017 data not yet available)",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/count/building_permits/construction/12/<zone>?start=20161231", //TODO need to add start date
                     zones: ["ward", "neighborhood_cluster", "zip"],
-                    default_layer: "ward"
+                    default_layer: "ward",
+                    style: "number"
                 },
                 {
                     name: "building_permits_all",
@@ -179,7 +183,8 @@
                     display_text: "Number of construction building permits issued in the zone during 2016. (2017 data not yet available)",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/count/building_permits/all/12/<zone>?start=20161231",
                     zones: ["ward", "neighborhood_cluster", "zip"],
-                    default_layer: "ward"
+                    default_layer: "ward",
+                    style: "number"
                 },
                 {
                     name: "poverty_rate",
@@ -187,7 +192,8 @@
                     display_text: "Fraction of residents below the poverty rate.",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/poverty_rate/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "census_tract"
+                    default_layer: "census_tract",
+                    style: "percent"
                 },
                 {
                     name: "income_per_capita",
@@ -195,7 +201,8 @@
                     display_text: "Average income per resident",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/income_per_capita/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "census_tract"
+                    default_layer: "census_tract",
+                    style: "money"
                 },
                 {
                     name: "labor_participation",
@@ -203,7 +210,8 @@
                     display_text: "Percent of the population that is working",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/labor_participation/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "census_tract"
+                    default_layer: "census_tract",
+                    style: "percent"
                 },
                 {
                     name: "fraction_single_mothers",
@@ -211,7 +219,8 @@
                     display_text: "Percent of the total population that is a single mother",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/fraction_single_mothers/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "census_tract"
+                    default_layer: "census_tract",
+                    style: "percent"
                 },
                 {
                     name: "fraction_black",
@@ -219,7 +228,8 @@
                     display_text: "Proportion of residents that are black or African American",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/fraction_black/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "census_tract"
+                    default_layer: "census_tract",
+                    style: "percent"
                 },
                 {
                     name: "fraction_foreign",
@@ -227,7 +237,8 @@
                     display_text: "Percent of the population that is foreign born",
                     url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/fraction_foreign/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
-                    default_layer: "census_tract"
+                    default_layer: "census_tract",
+                    style: "percent"
                 }
                 
             ];

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -145,56 +145,91 @@
                     name: "crime_violent_12",
                     display_name: "Crime Rate: Violent 12 months",
                     display_text: "Number of violent crime incidents per 100,000 people reported in the past 12 months.",
-                    zones: ["ward", "neighborhood_cluster", "census_tract", "zip"],
-                    aggregate_endpoint_base: "http://127.0.0.1:5000/api/rate/crime/violent/12/",
-                    available_aggregates: ["ward", "neighborhood_cluster", "census_tract", "zip"],
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/rate/crime/violent/12/<zone>",
+                    zones: ["ward", "neighborhood_cluster", "census_tract"],
                     default_layer: "ward"
                 },
                 {
                     name: "crime_nonviolent_12",
                     display_name: "Crime Rate: Non-Violent 12 months",
                     display_text: "Number of non-violent crime incidents per 100,000 people reported in this zone in the past 12 months.",
-                    zones: ["ward", "neighborhood_cluster", "census_tract", "zip"],
-                    aggregate_endpoint_base: "http://127.0.0.1:5000/api/rate/crime/nonviolent/12/",
-                    available_aggregates: ["ward", "neighborhood_cluster", "census_tract", "zip"],
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/rate/crime/nonviolent/12/<zone>",
+                    zones: ["ward", "neighborhood_cluster", "census_tract"],
                     default_layer: "ward"
                 },
                 {
                     name: "crime_all_3",
                     display_name: "Crime Rate: All 3 months",
                     display_text: "Total number of crime incidents per 100,000 people reported in the past 12 months.",
-                    zones: ["ward", "neighborhood_cluster", "census_tract", "zip"],
-                    aggregate_endpoint_base: "http://127.0.0.1:5000/api/rate/crime/all/3/",
-                    available_aggregates: ["ward", "neighborhood_cluster", "census_tract", "zip"],
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/rate/crime/all/3/<zone>",
+                    zones: ["ward", "neighborhood_cluster", "census_tract"],
                     default_layer: "ward"
                 },
                 {
                     name: "building_permits_construction",
                     display_name: "Building Permits: Construction 2016",
                     display_text: "Number of construction building permits issued in the zone during 2016. (2017 data not yet available)",
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/count/building_permits/construction/12/<zone>?start=20161231", //TODO need to add start date
                     zones: ["ward", "neighborhood_cluster", "zip"],
-                    aggregate_endpoint_base: "http://127.0.0.1:5000/api/count/building_permits/construction/12/", //TODO need to add start date
-                    available_aggregates: ["ward", "neighborhood_cluster", "zip"],
                     default_layer: "ward"
                 },
                 {
                     name: "building_permits_all",
                     display_name: "Building Permits: All 2016",
                     display_text: "Number of construction building permits issued in the zone during 2016. (2017 data not yet available)",
-                    aggregate_endpoint_base: "http://127.0.0.1:5000/api/count/building_permits/all/12/",
-                    available_aggregates: ["ward", "neighborhood_cluster", "zip"],
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/count/building_permits/all/12/<zone>?start=20161231",
                     zones: ["ward", "neighborhood_cluster", "zip"],
                     default_layer: "ward"
                 },
                 {
                     name: "poverty_rate",
-                    display_name: "Poverty Rate",
+                    display_name: "ACS: Poverty Rate",
                     display_text: "Fraction of residents below the poverty rate.",
-                    aggregate_endpoint_base: "http://127.0.0.1:5000/api/census/poverty_rate/",
-                    available_aggregates: ["ward", "neighborhood_cluster", "census_tract"],
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/poverty_rate/<zone>",
                     zones: ["ward", "neighborhood_cluster", "census_tract"],
                     default_layer: "census_tract"
                 },
+                {
+                    name: "income_per_capita",
+                    display_name: "ACS: Income Per Capita",
+                    display_text: "Average income per resident",
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/income_per_capita/<zone>",
+                    zones: ["ward", "neighborhood_cluster", "census_tract"],
+                    default_layer: "census_tract"
+                },
+                {
+                    name: "labor_participation",
+                    display_name: "ACS: Labor Participation",
+                    display_text: "Percent of the population that is working",
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/labor_participation/<zone>",
+                    zones: ["ward", "neighborhood_cluster", "census_tract"],
+                    default_layer: "census_tract"
+                },
+                {
+                    name: "fraction_single_mothers",
+                    display_name: "ACS: Fraction Single Mothers",
+                    display_text: "Percent of the total population that is a single mother",
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/fraction_single_mothers/<zone>",
+                    zones: ["ward", "neighborhood_cluster", "census_tract"],
+                    default_layer: "census_tract"
+                },
+                {
+                    name: "fraction_black",
+                    display_name: "ACS: Fraction Black",
+                    display_text: "Proportion of residents that are black or African American",
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/fraction_black/<zone>",
+                    zones: ["ward", "neighborhood_cluster", "census_tract"],
+                    default_layer: "census_tract"
+                },
+                {
+                    name: "fraction_foreign",
+                    display_name: "ACS: Fraction Foreign",
+                    display_text: "Percent of the population that is foreign born",
+                    url_format: "http://hiapidemo.us-east-1.elasticbeanstalk.com/api/census/fraction_foreign/<zone>",
+                    zones: ["ward", "neighborhood_cluster", "census_tract"],
+                    default_layer: "census_tract"
+                }
+                
             ];
         },
 
@@ -340,7 +375,8 @@
                 }
 
                 var overlayConfig = mapView.findOverlayConfig('name', data.overlay)
-                var url = overlayConfig.aggregate_endpoint_base + data.activeLayer;
+                var url = overlayConfig.url_format.replace('<zone>',data.activeLayer)
+
                 var dataRequest = {
                     name: data.overlay + "_" + data.activeLayer, //e.g. crime
                     url: url,
@@ -389,7 +425,7 @@
         },
         updateZoneChoiceDisabling: function(msg,data) { // e.g. data = {overlay:'crime',grouping:'neighborhood_cluster',activeLayer:'neighborhood_cluster'}
             //Checks to see if the current overlay is different from previous overlay
-            //If so, use the 'available_aggregates' to enable/disable zone selection buttons
+            //If so, use the 'zones' to enable/disable zone selection buttons
             
             var layerMenu = d3.select('#layer-menu').classed("myclass",true)
             layerMenu.selectAll('a')

--- a/python/api/application.py
+++ b/python/api/application.py
@@ -283,7 +283,7 @@ def items_divide(numerator_data, denominator_data):
         for n in numerator_data['items']:
             #TODO what should we do when a matching item isn't found?
             matching_d = next((item for item in denominator_data['items'] if item['group'] == n['group']),{'group':'_unknown','count':None})
-            if matching_d['count'] == None:
+            if matching_d['count'] == None or n['count']== None:
                 divided = None
             else:
                 divided = n['count'] / matching_d['count']

--- a/python/api/application.py
+++ b/python/api/application.py
@@ -277,12 +277,19 @@ def items_divide(numerator_data, denominator_data):
     and 'count'
     '''
     items = []
-    for n in numerator_data['items']:
-        #TODO what should we do when a matching item isn't found? currently returning default of 1 so that division will go through
-        matching_d = next((item for item in denominator_data['items'] if item['group'] == n['group']),{'group':'Unknown','count':1})
-        divided = n['count'] / matching_d['count']
-        item = dict({'group':n['group'], 'count':divided}) #TODO here and elsewhere need to change 'count' to 'value' for clarity, but need to fix front end to expect this first
-        items.append(item)
+    if numerator_data['items'] == None:
+        items=None
+    else:
+        for n in numerator_data['items']:
+            #TODO what should we do when a matching item isn't found?
+            matching_d = next((item for item in denominator_data['items'] if item['group'] == n['group']),{'group':'_unknown','count':None})
+            if matching_d['count'] == None:
+                divided = None
+            else:
+                divided = n['count'] / matching_d['count']
+
+            item = dict({'group':n['group'], 'count':divided}) #TODO here and elsewhere need to change 'count' to 'value' for clarity, but need to fix front end to expect this first
+            items.append(item)
 
     return {'items':items, 'grouping':numerator_data['grouping'], 'data_id':numerator_data['grouping']}
 
@@ -293,7 +300,10 @@ def scale(data,factor):
     '''
 
     for idx, d in enumerate(data['items']):
-        data['items'][idx]['count'] = (data['items'][idx]['count'] * factor)
+        try:
+            data['items'][idx]['count'] = (data['items'][idx]['count'] * factor)
+        except Exception as e:
+            data['items'][idx]['count'] = None
 
     return data
 

--- a/python/api/requirements.txt
+++ b/python/api/requirements.txt
@@ -11,3 +11,4 @@ SQLAlchemy==1.1.9
 Werkzeug==0.12.1
 simplejson==3.10.0
 six==1.10.0
+python-dateutil


### PR DESCRIPTION
- Adds a finalized list of demo layers to the view, and fixes various logical bugs needed to make different types of data work (percents, missing values, etc.) 
- Adds number formatting for various data types to legend (percent, $, commas)

This messes up the 'one less' logic for the max of a range (e.g. 0 to 499, 500-999) and instead uses the same number for top of one range and bottom of the next one. Had to switch it because the "minus 1" logic failed for percents. Put a TODO to fix this. 

Again @ptgott or @ostermanj would be great to get a review, though I'm going to go ahead and merge as it gives us a bunch of needed functionality for user tests. 