### PR TITLE
Puts overlay layers below the project layer so that circles are always on top.

### DIFF
--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -433,7 +433,7 @@
                             },
                             'fill-opacity': 1 //using rgba in the chloropleth color range instead
                         }
-                    });
+                    }, 'project');
 
                 console.log(data.chloroplethRange.stopsAscending);
                 };


### PR DESCRIPTION
I wish all fixes were so easy. mapBox addLayer method can specify which layer the new added one should be before. The line now specifies "projects." Overlays now all underneath projects so long as the project layer is loaded before someone selects an overlay. That should be the case.