### PR TITLE
314 add geocode

### DIFF
--- a/python/housinginsights/sources/base.py
+++ b/python/housinginsights/sources/base.py
@@ -184,6 +184,13 @@ class BaseApiConn(object):
                     data[field] = None
             else:
                 data[field] = line[value]
+
+            # clean opendata 'GIS_DTTM' formatting - convert milliseconds
+            if value == 'GIS_LAST_MOD_DTTM':
+                milli_sec = int(line[value])
+                data[field] = \
+                    datetime.fromtimestamp(milli_sec / 1000.0).strftime(
+                        '%m/%d/%Y')
         return data
 
     def _get_nlihc_id_from_db(self, db_conn, address_id):
@@ -204,7 +211,6 @@ class BaseApiConn(object):
             return result[0]['nlihc_id'], True
         else:
             return str(uuid4()), False
-
 
     def create_project_subsidy_csv(self, uid, project_fields_map,
                                    subsidy_fields_map, database_choice=None):

--- a/python/housinginsights/sources/models/pres_cat.py
+++ b/python/housinginsights/sources/models/pres_cat.py
@@ -38,3 +38,51 @@ SUBSIDY_FIELDS = ['Nlihc_id', 'Subsidy_id',
                       'Subsidy_info_source_property',
                       'POA_end_actual']
 
+CLUSTER_DESC_MAP = {
+    'Cluster 1': 'Kalorama Heights, Adams Morgan, Lanier Heights',
+    'Cluster 2': 'Columbia Heights, Mt. Pleasant, Pleasant Plains, Park View',
+    'Cluster 3': 'Howard University, Le Droit Park, Cardozo/Shaw',
+    'Cluster 4': 'Georgetown, Burleith/Hillandale',
+    'Cluster 5': 'West End, Foggy Bottom, GWU',
+    'Cluster 6': 'Dupont Circle, Connecticut Avenue/K Street',
+    'Cluster 7': 'Shaw, Logan Circle',
+    'Cluster 8': 'Downtown, Chinatown, Penn Quarters, Mount Vernon Square,'
+    'North Capitol Street',
+    'Cluster 9': 'Southwest Employment Area, Southwest/Waterfront, Fort McNair,'
+    'Buzzard Point',
+    'Cluster 10': 'Hawthorne, Barnaby Woods, Chevy Chase',
+    'Cluster 11': 'Friendship Heights, American University Park, Tenleytown',
+    'Cluster 12': 'North Cleveland Park, Forest Hills, Van Ness',
+    'Cluster 13': 'Spring Valley, Palisades, Wesley Heights, Foxhall Crescent,'
+                  'Foxhall Village, Georgetown Reservoir',
+    'Cluster 14': 'Cathedral Heights, McLean Gardens, Glover Park',
+    'Cluster 15': 'Cleveland Park, Woodley Park, Massachusetts Avenue Heights,'
+                  'Woodland-Normanstone Terrace',
+    'Cluster 16': 'Colonial Village, Shepherd Park, North Portal Estates',
+    'Cluster 17': 'Takoma, Brightwood, Manor Park',
+    'Cluster 18': 'Brightwood Park, Crestwood, Petworth',
+    'Cluster 19': 'Lamond Riggs, Queens Chapel, Fort Totten, Pleasant Hill',
+    'Cluster 20': 'North Michigan Park, Michigan Park, University Heights',
+    'Cluster 21': 'Edgewood, Bloomingdale, Truxton Circle, Eckington',
+    'Cluster 22': 'Brookland, Brentwood, Langdon',
+    'Cluster 23': 'Ivy City, Arboretum, Trinidad, Carver Langston',
+    'Cluster 24': 'Woodridge, Fort Lincoln, Gateway',
+    'Cluster 25': 'NoMa, Union Station, Stanton Park, Kingman Park',
+    'Cluster 26': 'Capitol Hill, Lincoln Park',
+    'Cluster 27': 'Near Southeast, Navy Yard',
+    'Cluster 28': 'Historic Anacostia',
+    'Cluster 29': 'Eastland Gardens, Kenilworth',
+    'Cluster 30': 'Mayfair, Hillbrook, Mahaning Heights',
+    'Cluster 31': 'Deanwood, Burrville, Grant Park, Lincoln Heights,'
+                  'Fairmont Heights',
+    'Cluster 32': 'River Terrace, Benning, Greenway, Fort Dupont',
+    'Cluster 33': 'Capitol View, Marshall Heights, Benning Heights',
+    'Cluster 34': 'Twining, Fairlawn, Randle Highlands, Penn Branch,'
+                  'Fort Davis Park, Dupont Park',
+    'Cluster 35': 'Fairfax Village, Naylor Gardens, Hillcrest, Summit Park',
+    'Cluster 36': 'Woodland/Fort Stanton, Garfield Heights, Knox Hill',
+    'Cluster 37': 'Sheridan, Barry Farm, Buena Vista',
+    'Cluster 38': 'Douglass, Shipley Terrace',
+    'Cluster 39': 'Congress Heights, Bellevue, Washington Highlands'
+}
+


### PR DESCRIPTION
Added methods to Cleaner module so that geographic zones in project table are encoded with data instead of nulls. I utilized api calls to MAR and added a cluster_desc_map dictionary object to prec_cat model. Since I was doing MAR api calls I also populated status for buildings that are unique with respect to those available in the prescat - that is, those that don't have a matching nlihc_id.