### PR TITLE
Map zooms in response to filtered projects

### DIFF
--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -36,7 +36,8 @@
                     ['previewBuilding', mapView.showPopup],
                     ['filteredData', mapView.filterMap],
                     ['hoverBuildingList', mapView.highlightBuilding],
-                    ['filterViewLoaded', mapView.initialSidebarState]
+                    ['filterViewLoaded', mapView.initialSidebarState],
+                    ['filteredProjectsAvailable',mapView.zoomToFilteredProjects]
                 ]);
 
 
@@ -994,5 +995,27 @@
                     'filter': ['==', 'nlihc_id', data]
                 });
             }
+        },
+        zoomToFilteredProjects: function(msg, data){
+            if (getState().filteredProjectsAvailable.length < 2 ) {
+                return; // disable function on first filter, which happens when the app first loads
+            }
+            var maxLat = d3.max(data, function(d){
+                return d.latitude;
+            });            
+            var minLat = d3.min(data, function(d){
+                return d.latitude;
+            });
+            var maxLon = d3.max(data, function(d){
+                if (d.longitude < 0 ) {
+                    return d.longitude; // workaround of data error where one project has positive longitude instead of positive
+                                        // can remove `if` statement when resolved (issue 405)                    
+                }
+            });
+            var minLon = d3.min(data, function(d){
+                return d.longitude;
+            });
+            console.log(minLon,minLat,maxLon,maxLat);
+            mapView.map.fitBounds([[minLon,minLat], [maxLon,maxLat]], {linear: true, padding: 20});
         }
     };

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -64,9 +64,9 @@
 
                     d3.select('#reset-zoom')
                         .style('display', function() {
-                            if (Math.abs(mapView.map.getZoom() - mapView.originalZoom) < 0.001 &&
-                                Math.abs(mapView.map.getCenter().lng - mapView.originalCenter[0]) < 0.001 &&
-                                Math.abs(mapView.map.getCenter().lat - mapView.originalCenter[1]) < 0.001) {
+                            if (Math.abs(mapView.map.getZoom() - mapView.originalZoom) < 0.1 &&
+                                Math.abs(mapView.map.getCenter().lng - mapView.originalCenter[0]) < 0.01 &&
+                                Math.abs(mapView.map.getCenter().lat - mapView.originalCenter[1]) < 0.01) {
                                 return 'none';
                             } else {
                                 return 'block';


### PR DESCRIPTION
re issue #397 

Subscribes to filteredProjectsAvailable state change; calculates bounding box of matching projects and zooms to fit the bounding back. mapBox, FTW, includes a `fitBounds()` method that handles this.

Includes workaround for issue #405 that can be removed when that issue is resolved.