### PR TITLE
393 - Place 'clear filter' labels at the top of the Data Choices menu

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.4.0)
     colorator (1.1.0)
     ffi (1.9.14)
+    ffi (1.9.14-x64-mingw32)
     forwardable-extended (2.6.0)
     jekyll (3.3.1)
       addressable (~> 2.4)
@@ -37,9 +38,10 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   jekyll (= 3.3.1)
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/docs/tool/css/filters.css
+++ b/docs/tool/css/filters.css
@@ -63,12 +63,6 @@
   left: 10px;
 }
 
-/* override the Semantic.js label styling for the Clear Filters button */
-#clearFiltersPillbox{
-    font-size: 1em !important;
-}
-
-
 /*Descriptive text*/
 
 .description .neighborhood-flag {

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -512,10 +512,12 @@ a.active {
     font-size: .95em;
     margin-top:5px;
     margin-left: 2px;
+    cursor: pointer;
 }
 
-
-
+.ui.label.clear-all:hover {
+    color: rgb(50, 50, 50) !important;
+}
 
 /* chloroplath legend */
 

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -114,12 +114,8 @@ html, body {
 }
 
 #clear-pillbox-holder {
-    position: absolute;
-    z-index:10;
-    top: 50px;
-    flex-grow: 1;
-    padding-left: 10px;
-    padding-right: 50px; /*allows space for mapbox zoom control*/
+    position: relative;
+    display: block;
 }
 
 .main-view {
@@ -494,9 +490,31 @@ a.active {
 /*Clear filter pillboxes*/
 .ui.label.clear-single {
     background-color: rgba(253,126,35,0.7);
+    display: block !important;
+    position: relative;
     font-size: .95em;
     margin-top:5px;
 }
+
+.ui.label.clear-single-flier {
+    background-color: rgba(253,126,35,0.7);
+    display: block;
+    position: absolute !important;
+    font-size: .95em;
+    z-index: 99999;
+    transition: left 1.5s, top 1.5s;
+}
+
+.ui.label.clear-all {
+    background-color: rgba(150,150,150,0.7);
+    display: block !important;
+    position: relative;
+    font-size: .95em;
+    margin-top:5px;
+    margin-left: 2px;
+}
+
+
 
 
 /* chloroplath legend */

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -29,7 +29,7 @@ var filterView = {
                         .data(activeFilterIds)
                         .classed("not-most-recent",true);
 
-        var allPills = oldPills.enter().append("div")
+        var newPills = oldPills.enter().append("div")
             .attr("class","ui label transition hidden")
             .classed("clear-single",true)
             // Animate a label that 'flies' from the filter component
@@ -66,14 +66,14 @@ var filterView = {
             });
 
         //Add the 'clear' x mark and its callback
-        allPills.each(function(d) {
+        newPills.each(function(d) {
             d3.select(this).append("i")
                 .classed("delete icon",true)
                 .on("click", function(d) {
                     d.clear();
                 })
-        })
-        .merge(oldPills);
+        });
+        var allPills = newPills.merge(oldPills);
 
         oldPills.exit().remove();
 

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -3,33 +3,30 @@
 var filterView = {
 
     addClearPillboxes: function(msg,data){
-    
-        for (var i=0; i < filterView.filterControls.length; i++){
-            var x = filterView.filterControls[i]['component']['source'] //display_name
-        }
 
         //Compare our activated filterValues (from the state module) to the list of all 
         //possible filterControls to make a list containing only the activated filter objects. 
         //filterValues = obj with keys of the 'source' data id and values of current setpoint
         //filterControls = list of objects that encapsulates the actual component including its clear() method
-        var activeFilterIds = []
-        var filterValues = filterUtil.getFilterValues()
-        for (var key in filterValues){
-            if (filterValues[key][0].length != 0){
-                var control = filterView.filterControls.find(function(obj){
-                    return obj['component']['source'] === key;
-                })
-                activeFilterIds.push(control)
-            };
-        }
-        
+        var filterValues = filterUtil.getFilterValues();
+
+        var keysWithActiveFilterValues = Object.keys(filterValues).filter(function(key){
+            return filterValues[key][0].length !== 0;
+        });
+
+        var activeFilterControls = filterView.filterControls.filter(function(filterControl){
+            return keysWithActiveFilterValues.indexOf(filterControl.component.source) !== -1;
+        });
+      
         //Use d3 to bind the list of control objects to our html pillboxes
-        var oldPills = d3.select('#clear-pillbox-holder')
+        var allPills = d3.select('#clear-pillbox-holder')
                         .selectAll('.clear-single')
-                        .data(activeFilterIds)
+                        .data(activeFilterControls, function(d){
+                            return d.component.source;
+                        })
                         .classed("not-most-recent",true);
 
-        var newPills = oldPills.enter().append("div")
+        allPills.enter().append("div")
             .attr("class","ui label transition hidden")
             .classed("clear-single",true)
             // Animate a label that 'flies' from the filter component
@@ -63,20 +60,15 @@ var filterView = {
                     destinationElement.classList.add('visible');
                 }, 1500);
 
-            });
-
+            })
         //Add the 'clear' x mark and its callback
-        newPills.each(function(d) {
-            d3.select(this).append("i")
-                .classed("delete icon",true)
-                .on("click", function(d) {
-                    d.clear();
-                })
-        });
-        var allPills = newPills.merge(oldPills);
-
-        oldPills.exit().remove();
-
+            .append('i')
+            .classed("delete icon",true)
+            .on("click", function(d) {
+                d.clear();
+            })
+                       
+        allPills.exit().remove();
     },
 
     init: function(msg, data) {

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -497,25 +497,17 @@ var filterView = {
 
             this.site = document.getElementById('clear-pillbox-holder');
 
-            this.trigger = document.createElement('i');
-            this.trigger.id = 'clearFiltersTrigger';
-            this.trigger.classList.add('delete', 'icon');
-
             this.site.insertBefore(this.pill, this.site.firstChild);
             this.pill.textContent = "Clear all filters";
-            this.pill.appendChild(this.trigger);
             
-            this.trigger.addEventListener('click', function(){
+            this.pill.addEventListener('click', function(){
                 filterView.clearAllFilters();
             });
         },
         site: undefined,
         tearDown: function(){
             this.pill.parentElement.removeChild(this.pill);
-            this.trigger.parentElement.removeChild(this.trigger);
-        },
-        trigger: undefined
-    },
+        }    },
 
     handleFilterClearance: function(message, data){
         if(data === true){

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -32,8 +32,36 @@ var filterView = {
         var allPills = oldPills.enter().append("div")
             .attr("class","ui label transition visible")
             .classed("clear-single",true)
-          .merge(oldPills)
-            .text(function(d) { return d['component']['display_name'];});
+            // Animate a label that 'flies' from the filter component
+            // to the pillbox.
+            .text(function(d) { return d['component']['display_name'];})
+            .each(function(d){
+                var originElement = document.getElementById("filter-content-"+d.component.source);
+                var destinationElement = this;
+                var flyLabel = document.createElement('div');
+                flyLabel.textContent = this.textContent;
+                console.log("flyer this", this);
+                flyLabel.classList.add('ui', 'label', 'transition', 'visible', 'clear-single-flier');
+                var originRect = originElement.getBoundingClientRect();
+                flyLabel.style.left = originRect.left + 'px';
+                flyLabel.style.top = ((originRect.top + originRect.bottom)/2) + 'px';
+                document.body.appendChild(flyLabel);
+                console.log("flyLabel after append", flyLabel);
+                // Change the 'top' and 'left' CSS properties of flyLabel,
+                // triggering its CSS transition.
+                window.setTimeout(function(){
+                    console.log("flyLabel destinationElement.clientLeft", destinationElement.clientLeft);
+                    console.log("flyLabel destinationElement.clientTop", destinationElement.clientTop);
+                    flyLabel.style.left = destinationElement.getBoundingClientRect().left + 'px';
+                    flyLabel.style.top = destinationElement.getBoundingClientRect().top + 'px';
+                }, 1);
+
+                // Remove flyLabel after its transition has elapsed.
+                window.setTimeout(function(){
+                    flyLabel.parentElement.removeChild(flyLabel);
+                }, 1500);
+
+            });
 
         //Add the 'clear' x mark and its callback
         allPills.each(function(d) {
@@ -42,7 +70,8 @@ var filterView = {
                 .on("click", function(d) {
                     d.clear();
                 })
-        });
+        })
+        .merge(oldPills);
 
         oldPills.exit().remove();
 
@@ -191,7 +220,7 @@ var filterView = {
         }
 
         this.isTouched = function(){
-            return slider.noUiSlider.get()[0] === c.min && slider.noUiSlider.get()[1] === c.max;
+            return slider.noUiSlider.get()[0] !== c.min && slider.noUiSlider.get()[1] !== c.max;
         }
 
     },
@@ -462,34 +491,26 @@ var filterView = {
 
             this.pill = document.createElement('div');
             this.pill.id = 'clearFiltersPillbox';
-            this.pill.classList.add('ui', 'label', 'transition', 'visible');
+            this.pill.classList.add('ui', 'label', 'transition', 'visible', 'clear-all');
 
-            this.site = document.getElementById('button-filters');
-            this.replacedText = this.site.innerText;
+            this.site = document.getElementById('clear-pillbox-holder');
 
             this.trigger = document.createElement('i');
             this.trigger.id = 'clearFiltersTrigger';
             this.trigger.classList.add('delete', 'icon');
 
-            this.site.innerText = "";
-
-            this.pill.innerText = this.replacedText;
-
-            this.site.appendChild(this.pill);
+            this.site.insertBefore(this.pill, this.site.firstChild);
+            this.pill.textContent = "Clear all filters";
             this.pill.appendChild(this.trigger);
             
             this.trigger.addEventListener('click', function(){
                 filterView.clearAllFilters();
             });
         },
-        replacedText: undefined,
         site: undefined,
         tearDown: function(){
-            console.log("this.pill", this.pill);
-            console.log("this.pill.parentElement", this.pill.parentElement);
             this.pill.parentElement.removeChild(this.pill);
             this.trigger.parentElement.removeChild(this.trigger);
-            this.site.innerText = this.replacedText;
         },
         trigger: undefined
     },

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -30,7 +30,7 @@ var filterView = {
                         .classed("not-most-recent",true);
 
         var allPills = oldPills.enter().append("div")
-            .attr("class","ui label transition visible")
+            .attr("class","ui label transition hidden")
             .classed("clear-single",true)
             // Animate a label that 'flies' from the filter component
             // to the pillbox.
@@ -45,13 +45,13 @@ var filterView = {
                 var originRect = originElement.getBoundingClientRect();
                 flyLabel.style.left = originRect.left + 'px';
                 flyLabel.style.top = ((originRect.top + originRect.bottom)/2) + 'px';
+                var flyLabelX = document.createElement('i');
+                flyLabelX.classList.add('delete', 'icon');
                 document.body.appendChild(flyLabel);
-                console.log("flyLabel after append", flyLabel);
+                flyLabel.appendChild(flyLabelX);
                 // Change the 'top' and 'left' CSS properties of flyLabel,
                 // triggering its CSS transition.
                 window.setTimeout(function(){
-                    console.log("flyLabel destinationElement.clientLeft", destinationElement.clientLeft);
-                    console.log("flyLabel destinationElement.clientTop", destinationElement.clientTop);
                     flyLabel.style.left = destinationElement.getBoundingClientRect().left + 'px';
                     flyLabel.style.top = destinationElement.getBoundingClientRect().top + 'px';
                 }, 1);
@@ -59,6 +59,8 @@ var filterView = {
                 // Remove flyLabel after its transition has elapsed.
                 window.setTimeout(function(){
                     flyLabel.parentElement.removeChild(flyLabel);
+                    destinationElement.classList.remove('hidden');
+                    destinationElement.classList.add('visible');
                 }, 1500);
 
             });

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -220,7 +220,9 @@ var filterView = {
         }
 
         this.isTouched = function(){
-            return slider.noUiSlider.get()[0] !== c.min && slider.noUiSlider.get()[1] !== c.max;
+            // Since the result of 'get()' is a string, coerce it into a number
+            // before determining equality.
+            return +slider.noUiSlider.get()[0] !== c.min || +slider.noUiSlider.get()[1] !== c.max;
         }
 
     },

--- a/docs/tool/partials/map-view.html
+++ b/docs/tool/partials/map-view.html
@@ -8,7 +8,6 @@
             <button class="sub-nav-button" id="button-filters">Data Choices</button>
         </div>
         <div id="options-spacer">
-            <div id="clear-pillbox-holder"></div><!--will be style positioned downwards-->
         </div>
         <div id="right-options">
             <button class="sub-nav-button" id="button-charts">Summary</button>
@@ -44,6 +43,7 @@
                 </div>
                 <div id="zone-choice-header" class="header">2) Data choices</div>
                     <div id="filter-components">
+                        <div id="clear-pillbox-holder"></div><!--will be style positioned downwards-->
                     </div>                
                 </div>
 


### PR DESCRIPTION
This PR also animates the 'clear filter' labels to fly from their associated UI components to their place among the other 'clear filter' labels. The aim here is to make it unmistakable that the orange labels emerge as a result of choosing filters, and that they move to the top of the Data Choices menu. 

Addresses #393 