### PR TITLE
Add nlihc_id to topa table #404

### DIFF
--- a/python/housinginsights/ingestion/Cleaners.py
+++ b/python/housinginsights/ingestion/Cleaners.py
@@ -508,7 +508,7 @@ class dchousing_cleaner(CleanerBase):
 
         return row
 
-class topa_cleaner(CleanerBase):
+class TopaCleaner(CleanerBase):
     def __init__(self, meta, manifest_row, cleaned_csv='', removed_csv='', engine=None):
         #Call the parent method and pass all the arguments as-is
         super().__init__(meta, manifest_row, cleaned_csv, removed_csv, engine)
@@ -517,19 +517,22 @@ class topa_cleaner(CleanerBase):
         # 2015 dataset provided by Urban Institute as provided in S3 has errant '\'
         # character in one or two columns.  Leave here for now.
         row = self.replace_nulls(row, null_values=['', '\\', None])
-        exists_in_project = self.address_id_exists(row['ADDRESS_ID'])
-        if exists_in_project:
-            pass #TODO Process these records a certain way.
+        nlihc_id = self.get_nlihc_id_if_exists(row['ADDRESS_ID'])
+        row['nlihc_id'] = nlihc_id
         return row
 
-    def address_id_exists(self, address_id):
+    def get_nlihc_id_if_exists(self, address_id):
         "Checks for record in project table with matching MAR id."
-        query = "select mar_id from project where mar_id = '{}'".format(address_id)
+        query = "select nlihc_id from project where mar_id = '{}'".format(address_id)
+        if address_id == self.null_value:
+            return self.null_value
         try:
-            result = self.engine.execute(query)
-            result.close()
+            result = self.engine.execute(query).fetchone()
+            if result:
+                return result[0]
         except:
-            return 0
+            return self.null_value
+        return self.null_value
 
 
 class Zone_HousingUnit_Bedrm_Count_cleaner(CleanerBase):

--- a/python/housinginsights/ingestion/Cleaners.py
+++ b/python/housinginsights/ingestion/Cleaners.py
@@ -29,9 +29,10 @@ http://stackoverflow.com/questions/4821104/python-dynamic-instantiation-from-str
 
 
 class CleanerBase(object, metaclass=ABCMeta):
-    def __init__(self, meta, manifest_row, cleaned_csv='', removed_csv=''):
+    def __init__(self, meta, manifest_row, cleaned_csv='', removed_csv='', engine=None):
         self.cleaned_csv = cleaned_csv
         self.removed_csv = removed_csv
+        self.engine = engine
 
         self.manifest_row = manifest_row
         self.tablename = manifest_row['destination_table']
@@ -508,11 +509,25 @@ class dchousing_cleaner(CleanerBase):
         return row
 
 class topa_cleaner(CleanerBase):
+    def __init__(self, meta, manifest_row, cleaned_csv='', removed_csv='', engine=None):
+        #Call the parent method and pass all the arguments as-is
+        super().__init__(meta, manifest_row, cleaned_csv, removed_csv, engine)
+
     def clean(self,row,row_num=None):
         # 2015 dataset provided by Urban Institute as provided in S3 has errant '\'
         # character in one or two columns.  Leave here for now.
         row = self.replace_nulls(row, null_values=['', '\\', None])
+        exists = self.address_id_exists(row['ADDRESS_ID'])
         return row
+
+    def address_id_exists(self, address_id):
+        "Checks for record in project table with matching MAR id."
+        query = "select mar_id from project where mar_id = '{}'".format(address_id)
+        try:
+            result = self.engine.execute(query)
+            result.close()
+        except:
+            return 0
 
 
 class Zone_HousingUnit_Bedrm_Count_cleaner(CleanerBase):

--- a/python/housinginsights/ingestion/Cleaners.py
+++ b/python/housinginsights/ingestion/Cleaners.py
@@ -517,7 +517,9 @@ class topa_cleaner(CleanerBase):
         # 2015 dataset provided by Urban Institute as provided in S3 has errant '\'
         # character in one or two columns.  Leave here for now.
         row = self.replace_nulls(row, null_values=['', '\\', None])
-        exists = self.address_id_exists(row['ADDRESS_ID'])
+        exists_in_project = self.address_id_exists(row['ADDRESS_ID'])
+        if exists_in_project:
+            pass #TODO Process these records a certain way.
         return row
 
     def address_id_exists(self, address_id):

--- a/python/housinginsights/ingestion/LoadData.py
+++ b/python/housinginsights/ingestion/LoadData.py
@@ -319,7 +319,8 @@ class LoadData(object):
         return ingestionfunctions.get_cleaner_from_name(
             meta=self.meta,
             manifest_row=manifest_row,
-            name=cleaner_class_name)
+            name=cleaner_class_name,
+            engine=self.engine)
 
     def _get_meta_only_fields(self, table_name, data_fields):
         """

--- a/python/housinginsights/ingestion/functions.py
+++ b/python/housinginsights/ingestion/functions.py
@@ -113,7 +113,7 @@ def check_or_create_sql_manifest(engine, rebuild=False):
             raise e
 
 
-def get_cleaner_from_name(meta, manifest_row, name="GenericCleaner"):
+def get_cleaner_from_name(meta, manifest_row, name="GenericCleaner", engine=None):
     """
     Returns the instance of the cleaner class matching the given cleaner class
     name.
@@ -127,7 +127,7 @@ def get_cleaner_from_name(meta, manifest_row, name="GenericCleaner"):
     #Import
     #module = import_module("module.submodule")
     Class_ = getattr(Cleaners, name)
-    instance = Class_(meta, manifest_row)
+    instance = Class_(meta, manifest_row, engine=engine)
     return instance
 
 

--- a/python/scripts/meta.json
+++ b/python/scripts/meta.json
@@ -3511,7 +3511,7 @@
     "replace_table": true
   },
   "topa": {
-    "cleaner": "topa_cleaner",
+    "cleaner": "TopaCleaner",
     "fields": [
       {
         "display_name": "Unique Data ID",
@@ -3632,6 +3632,14 @@
         "source_name": "ADDRESS_ID",
         "sql_name": "address_id",
         "type": "decimal"
+      },
+      {
+        "display_name": "NLIHC_id",
+        "display_text": "The NLIHC ID as matched from project table.",
+        "required_in_source": false,
+        "source_name": "nlihc_id",
+        "sql_name": "nlihc_id",
+        "type": "text"
       },
       {
         "display_name": "ANC 2002",


### PR DESCRIPTION
I made some modifications which allow for the topa cleaner to verify existence of a record in the project table with a given address id (MAR id). It was a bit trickier than expected.

Given this functionality, I am not sure about next steps. My notes say that we want to add a new field called nlihc_id to the topa table and populate it if it exists, but wouldn't it just be a duplicate of the existing address_id? Perhaps a boolean field would be better so as not to duplicate data? I'm afraid I don't understand how the field will be used.

This PR is currently stable - so I am happy to keep working with further guidance, or to hand off to someone to polish off (I do think the remaining work should be the "easy" part).

Thanks as always.