### PR TITLE
WIP: 388 zone facts table

### DIFF
--- a/python/housinginsights/ingestion/LoadData.py
+++ b/python/housinginsights/ingestion/LoadData.py
@@ -314,6 +314,9 @@ class LoadData(object):
             # add to db
             metadata.create_all(tables=[zone_facts])
 
+            # populate table with calculated fields values
+            self._add_census_with_weighting_fields_to_zone_facts_table()
+
         return metadata.tables
 
     def _add_census_with_weighting_fields_to_zone_facts_table(self):

--- a/python/housinginsights/ingestion/LoadData.py
+++ b/python/housinginsights/ingestion/LoadData.py
@@ -22,7 +22,9 @@ import os
 import logging
 import argparse
 import json
-from sqlalchemy import Table, Column, Integer, String, MetaData
+from audioop import bias
+
+from sqlalchemy import Table, Column, Integer, String, MetaData, Numeric
 
 # Needed to make relative package imports when running this file as a script
 # (i.e. for testing purposes).
@@ -243,6 +245,9 @@ class LoadData(object):
                 self._process_data_file(manifest_row=manifest_row)
                 processed_data_ids.append(uid)
 
+        # build Zone Facts table
+        self._create_zone_facts_table()
+
         return processed_data_ids
 
     def _get_temp_filepath(self, manifest_row):
@@ -290,26 +295,224 @@ class LoadData(object):
         return processed_data_ids
 
     def _create_zone_facts_table(self):
-        # drop zone_facts table if already in db
-        if 'zone_facts' in self.engine.table_names():
-            query = 'DROP TABLE zone_facts;'
-            self.engine.connect().execute(query)
+        with self.engine.connect() as conn:
+            # drop zone_facts table if already in db
+            if 'zone_facts' in self.engine.table_names():
+                conn.execute('DROP TABLE zone_facts;')
 
-        # build zone_facts table
-        metadata = MetaData(bind=self.engine)
-        zone_facts = Table('zone_facts', metadata,
-                           Column('zone', String, primary_key=True),
-                           Column('census_with_weighting', String),
-                           Column('poverty_rate', Integer),
-                           Column('fraction_black', Integer),
-                           Column('income_per_capita', Integer),
-                           Column('labor_participation', Integer),
-                           Column('fraction_foreign', Integer),
-                           Column('fraction_single_mothers', Integer))
+            # create empty zone_facts table
+            metadata = MetaData(bind=self.engine)
+            zone_facts = Table('zone_facts', metadata,
+                               Column('zone', String, primary_key=True),
+                               Column('poverty_rate', Numeric),
+                               Column('fraction_black', Numeric),
+                               Column('income_per_capita', Numeric),
+                               Column('labor_participation', Numeric),
+                               Column('fraction_foreign', Numeric),
+                               Column('fraction_single_mothers', Numeric))
 
-        # add to db
-        metadata.create_all()
+            # add to db
+            metadata.create_all(tables=[zone_facts])
+
         return metadata.tables
+
+    def _add_census_with_weighting_fields_to_zone_facts_table(self):
+        census_with_weighting_fields = [
+            'poverty_rate', 'fraction_black', 'income_per_capita',
+            'labor_participation', 'fraction_foreign',
+            'fraction_single_mothers'
+        ]
+
+        zone_types = ['ward', 'neighborhood_cluster', 'census_tract']
+
+        query_results = list()
+
+        # populate columns accordingly for each zone_specific type
+        for zone_type in zone_types:
+            field_values = dict()
+
+            # get field value for each zone_specific type
+            for field in census_with_weighting_fields:
+                result = self._census_with_weighting(data_id=field,
+                                                     grouping=zone_type)
+                field_values[field] = result['items']
+
+            zone_specifics = self._get_zone_specifics_for_zone_type(zone_type)
+
+            # TODO: add aggregate for each zone_type into table
+            for zone in zone_specifics:
+                # get not None values so we can added to db
+                columns = list()
+                values = list()
+                for field in census_with_weighting_fields:
+                    zone_value = field_values[field][zone]
+
+                    if zone_value is not None:
+                        columns.append(field)
+                        values.append("'" + str(zone_value) + "'")
+
+                # derive column and values strings needed for sql query
+                columns = ', '.join(columns)
+                columns = 'zone, ' + columns
+
+                values = ', '.join(values)
+                values = "'" + zone + "', " + values
+
+                q = "INSERT INTO zone_facts ({cols}) VALUES ({vals})".format(
+                    cols=columns, vals=values)
+
+                with self.engine.connect() as conn:
+                    result = conn.execute(q)
+                    query_results.append(result)
+
+        return query_results
+
+    def _get_zone_specifics_for_zone_type(self, zone_type):
+        """
+        Returns a list of zone_specific values for a given zone_type.
+        """
+        with self.engine.connect() as conn:
+
+            if zone_type == 'ward':
+                table = 'project'
+            elif zone_type == 'neighborhood_cluster':
+                table = 'census_tract_to_neighborhood_cluster'
+            else:
+                table = 'census'
+
+            query_result = conn.execute(
+                'select distinct {zone} from {table};'.format(zone=zone_type,
+                                                              table=table))
+            zone_specifics = [row[0] for row in query_result.fetchall()]
+            # zones.append(zone)
+
+        return zone_specifics
+
+    def _items_divide(self, numerator_data, denominator_data):
+        """
+        Divides items in the numerator by items in the denominator by matching
+        the appropriate groupings.
+
+        Takes data that is formatted for output the API, i.e. a dictionary
+        with key "items", which contains a list of dictionaries each with 'grouping'
+        and 'count'
+        """
+        items = {}
+        if numerator_data['items'] is None:
+            items = None
+        else:
+            for n in numerator_data['items']:
+                # TODO what should we do when a matching item isn't found?
+                matching_d = next((item for item in denominator_data['items'] if
+                                   item['group'] == n['group']),
+                                  {'group': '_unknown', 'value': None})
+                if matching_d['value'] == None or n['value'] == None:
+                    divided = None
+                else:
+                    divided = n['value'] / matching_d['value']
+
+                # item = dict({'group': n['group'],
+                #              'value': divided})
+                items[n['group']] = divided
+
+        return {'items': items, 'grouping': numerator_data['grouping'],
+                'data_id': numerator_data['data_id']}
+
+    def _census_with_weighting(self, data_id, grouping):
+        """
+        Zone facts table helper function to get data from our census table.
+        data_id can either be a column name or a custom calculated value.
+
+        data_id: if in the list of calculated values, perform custom
+        calculation. Otherwise, try to get it from the census database table as
+        a column name.
+
+        grouping: either 'census_tract', 'ward', or 'neighborhood_cluster'
+        """
+        calculated_values = {
+            'poverty_rate': 'population_poverty',
+            'fraction_black': 'population_black',
+            'income_per_capita': 'aggregate_income',
+            'labor_participation': 'population_working',
+            'fraction_foreign': 'population_foreign',
+            'fraction_single_mothers': 'population_single_mother'
+        }
+
+        if data_id in calculated_values:
+
+            field = calculated_values[data_id]
+            numerator = self._get_weighted_census_results(grouping, field)
+            denominator = self._get_weighted_census_results(grouping,
+                                                            'population')
+
+            api_results = self._items_divide(numerator, denominator)
+            api_results['data_id'] = data_id
+
+        # If the data_id isn't one of our custom ones, assume it is a column name
+        else:
+            api_results = self._get_weighted_census_results(grouping, data_id)
+
+        return api_results
+
+    def _get_weighted_census_results(self, grouping, field):
+        """
+        Queries the census table for the relevant field and returns the results
+        as a weighted count returns the standard 'items' format.
+
+        Currently only implemented for the 'counts' weighting factor not for
+        the proportion version.
+        """
+        with self.engine.connect() as conn:
+            q = "SELECT census_tract, {field} FROM census".format(
+                field=field)  # TODO need to add 'year' column for multiple census years when this is added to the data
+            proxy = conn.execute(q)
+            census_results = [dict(x) for x in proxy.fetchall()]
+
+            # Transform the results
+            items = []  # For storing results as we go
+
+            if grouping == 'census_tract':
+                # No weighting required, data already in proper format
+                for r in census_results:
+                    output = dict({'group': r['census_tract'],
+                                   'value': r[field]})
+                    items.append(output)
+
+            elif grouping in ['ward', 'neighborhood_cluster']:
+                proxy = conn.execute(
+                    "SELECT DISTINCT {grouping} FROM census_tract_to_{grouping}".format(
+                        grouping=grouping))
+                groups = [x[0] for x in proxy.fetchall()]
+
+                for group in groups:
+                    proxy = conn.execute(
+                        "SELECT * FROM census_tract_to_{grouping} WHERE {grouping} = '{group}'".format(
+                            grouping=grouping, group=group))
+                    results = [dict(x) for x in proxy.fetchall()]
+
+                    count = 0
+                    for result in results:
+                        tract = result['census_tract']
+                        factor = result['population_weight_counts']
+                        matching_data = next((item for item in census_results if
+                                              item["census_tract"] == tract),
+                                             {field: None})
+                        if matching_data[field] is None:
+                            logging.warning(
+                                "Missing data for census tract when calculating weightings: {}".format(
+                                    tract))
+                            matching_data[field] = 0
+
+                        value = matching_data[field]
+                        count += (value * factor)
+
+                    output = dict({'group': group, 'value': round(count, 0)})
+                    items.append(output)
+            else:
+                # Invalid grouping
+                items = None
+
+        return {'items': items, 'grouping': grouping, 'data_id': field}
 
     def _process_data_file(self, manifest_row):
         """

--- a/python/housinginsights/ingestion/LoadData.py
+++ b/python/housinginsights/ingestion/LoadData.py
@@ -304,9 +304,9 @@ class LoadData(object):
         :return: a immutable dict that contains the tables structure of the
         table and sqlAlchemy metadata object used.
         """
-        with self.engine.connect() as conn:
-            # drop zone_facts table if already in db
-            if 'zone_facts' in self.engine.table_names():
+        # drop zone_facts table if already in db
+        if 'zone_facts' in self.engine.table_names():
+            with self.engine.connect() as conn:
                 conn.execute('DROP TABLE zone_facts;')
 
         # create empty zone_facts table

--- a/python/tests/test_load_data.py
+++ b/python/tests/test_load_data.py
@@ -127,9 +127,11 @@ class MyTestCase(unittest.TestCase):
         result_path = self.loader.make_manifest(folder_path)
         self.assertEqual(self.loader.manifest.path, result_path)
 
-    # TODO - write test code
-    def test__remove_existing_data(self):
-        pass
+    def test__create_zone_facts_table(self):
+        # self.loader.rebuild()
+        print(self.loader._create_zone_facts_table())
+        result = 'zone_facts' in self.loader.engine.table_names()
+        self.assertTrue(result, 'zone_facts table is in db')
 
 
 if __name__ == '__main__':

--- a/python/tests/test_load_data.py
+++ b/python/tests/test_load_data.py
@@ -127,11 +127,49 @@ class MyTestCase(unittest.TestCase):
         result_path = self.loader.make_manifest(folder_path)
         self.assertEqual(self.loader.manifest.path, result_path)
 
+    def test__get_zone_fact_zones(self):
+        ward_types = self.loader._get_zone_specifics_for_zone_type('ward')
+
+        for idx in range(9):
+            ward = "Ward " + str(idx) if idx > 0 else 'ward'
+            self.assertTrue(ward in ward_types)
+
     def test__create_zone_facts_table(self):
-        # self.loader.rebuild()
+        print(self.loader.engine.table_names())
         print(self.loader._create_zone_facts_table())
+        print(self.loader.engine.table_names())
         result = 'zone_facts' in self.loader.engine.table_names()
         self.assertTrue(result, 'zone_facts table is in db')
+
+    def test__get_weighted_census_results(self):
+        grouping = 'ward'
+        field = 'population_poverty'
+        data_id = 'poverty_rate'
+
+        numerator = self.loader._get_weighted_census_results(grouping,
+                                                             field)
+        print(numerator)
+        print()
+        denominator = self.loader._get_weighted_census_results(grouping,
+                                                               'population')
+        print(denominator)
+        print()
+        result = self.loader._items_divide(numerator, denominator)
+        print(result)
+        print()
+
+        result = self.loader._census_with_weighting(data_id, grouping)
+        print(result)
+
+        self.assertEqual(True, False)
+
+    def test__add_census_with_weighting_fields_to_zone_facts_table(self):
+        self.loader._create_zone_facts_table()
+        result = self.loader\
+            ._add_census_with_weighting_fields_to_zone_facts_table()
+        print(result)
+
+        self.assertEqual(True, False)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_load_data.py
+++ b/python/tests/test_load_data.py
@@ -128,6 +128,7 @@ class MyTestCase(unittest.TestCase):
         self.assertEqual(self.loader.manifest.path, result_path)
 
     def test__get_zone_fact_zones(self):
+        # TODO: breaks because temp modified code to exclude original zone_type
         ward_types = self.loader._get_zone_specifics_for_zone_type('ward')
 
         for idx in range(9):
@@ -135,9 +136,20 @@ class MyTestCase(unittest.TestCase):
             self.assertTrue(ward in ward_types)
 
     def test__create_zone_facts_table(self):
-        print(self.loader.engine.table_names())
-        print(self.loader._create_zone_facts_table())
-        print(self.loader.engine.table_names())
+        # make sure zone_facts is not in db
+        with self.loader.engine.connect() as conn:
+            conn.execute('drop table zone_facts;')
+
+        # currently no zone_facts table
+        result = 'zone_facts' in self.loader.engine.table_names()
+        self.assertFalse(result, 'zone_facts table is not in db')
+
+        # check returned metadata.tables contains 'zone_facts' table
+        result = self.loader._create_zone_facts_table().keys()
+        self.assertTrue('zone_facts' in result, 'zone_facts is in '
+                                                'metadata.tables object')
+
+        # confirm zone_facts table was loaded into db
         result = 'zone_facts' in self.loader.engine.table_names()
         self.assertTrue(result, 'zone_facts table is in db')
 

--- a/python/tests/test_load_data.py
+++ b/python/tests/test_load_data.py
@@ -137,8 +137,9 @@ class MyTestCase(unittest.TestCase):
 
     def test__create_zone_facts_table(self):
         # make sure zone_facts is not in db
-        with self.loader.engine.connect() as conn:
-            conn.execute('drop table zone_facts;')
+        if 'zone_facts' in self.loader.engine.table_names():
+            with self.loader.engine.connect() as conn:
+                conn.execute('DROP TABLE zone_facts;')
 
         # currently no zone_facts table
         result = 'zone_facts' in self.loader.engine.table_names()

--- a/python/tests/test_load_data.py
+++ b/python/tests/test_load_data.py
@@ -179,10 +179,13 @@ class MyTestCase(unittest.TestCase):
     def test__add_census_with_weighting_fields_to_zone_facts_table(self):
         self.loader._create_zone_facts_table()
         result = self.loader\
-            ._add_census_with_weighting_fields_to_zone_facts_table()
+            ._populate_zone_facts_table()
         print(result)
 
         self.assertEqual(True, False)
+
+    def test__add_census_acs_quartiles_to_zone_facts_table(self):
+        pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What's new

1. Added a function that runs after all data loading is completed that drops the existing records from the zone_facts table and rebuilds the table.

1. Includes function that generates the values used in zone column ensuring that they match the relevant standard column name and zone_specific match the value for that column that is used in other tables.

1. Populate the zone_facts table with calculated fields from the "census_with_weighting" api endpoint: 'poverty_rate', 'fraction_black', 'income_per_capita', 'labor_participation', 'fraction_foreign', 'fraction_single_mothers'.

## Testing
I need to complete unit test code so it is more robust.

To test:
- simply rebuild the database by running `python python/housinginsights/ingestion/LoadData.py docker` - assuming your currently at the `..\housing-insights` folder
- review db to confirm zone_facts table exists and its populated with zone_specifics for ward, census_tract, and neighborhood_cluster zone_types along with calculated fields.
