### PR TITLE
Resets originalCenter and originalZoom after the first zoom to projects.

### DIFF
--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -894,9 +894,6 @@
             }
         },
         zoomToFilteredProjects: function(msg, data){
-            if (getState().filteredProjectsAvailable.length < 2 ) {
-                return; // disable function on first filter, which happens when the app first loads
-            }
             var maxLat = d3.max(data, function(d){
                 return d.latitude;
             });            
@@ -914,5 +911,9 @@
             });
             console.log(minLon,minLat,maxLon,maxLat);
             mapView.map.fitBounds([[minLon,minLat], [maxLon,maxLat]], {linear: true, padding: 20});
+            if (getState().filteredProjectsAvailable.length === 1 ) { // if initial onload zoom, reset the originalCenter and originalZoom
+                mapView.map.originalCenter = [mapView.map.getCenter().lng, mapView.map.getCenter().lat];
+                mapView.map.originalZoom = mapView.map.getZoom();
+            }
         }
     };


### PR DESCRIPTION
This is a small addition to merged PR #408. The map initially loads according to hard-coded originalCenter and originalZoom variables; those settings are now overwritten after the first `zoomToFilteredProjects` takes place (after initial projects load), so that the settings will be adapt to potential project additions in the future.