### PR TITLE
430 calculated project fields reac

### DIFF
--- a/python/housinginsights/ingestion/LoadData.py
+++ b/python/housinginsights/ingestion/LoadData.py
@@ -247,6 +247,7 @@ class LoadData(object):
 
         # build Zone Facts table
         self._create_zone_facts_table()
+        self._populate_calculated_project_fields()
 
         return processed_data_ids
 
@@ -290,7 +291,7 @@ class LoadData(object):
             processed_data_ids.append(manifest_row['unique_data_id'])
 
         # build Zone Facts table
-        self._automap()
+        #self._automap() #not yet used - created for potential use by calculated fields
         self._create_zone_facts_table()
         self._populate_calculated_project_fields()
 

--- a/python/scripts/load_data.py
+++ b/python/scripts/load_data.py
@@ -35,7 +35,7 @@ description = ('Loads our flat file data into the database of choice. You '
 parser = argparse.ArgumentParser(description=description)
 parser.add_argument("database", help='which database the data should be '
                                      'loaded to',
-                    choices=['docker', 'docker_local', 'local', 'remote'])
+                    choices=['docker', 'docker_local', 'local', 'remote', 'codefordc'])
 parser.add_argument('-s', '--sample', help='load with sample data',
                     action='store_true')
 parser.add_argument('--update-only', nargs='+',
@@ -44,6 +44,8 @@ parser.add_argument('--update-only', nargs='+',
 parser.add_argument('--manual', help='Ignore all other arguments and use'
                     'what is hard coded here, for debugging/testing purposes',
                     action='store_true')
+parser.add_argument ('--recalculate-only',action='store_true',
+                    help="Don't update any data, just redo calculated fields")
 
 arguments = parser.parse_args()
 

--- a/python/scripts/meta.json
+++ b/python/scripts/meta.json
@@ -2390,6 +2390,30 @@
         "type": "text"
       },
       {
+        "display_name": "Most Recent REAC Score",
+        "display_text": "From the REAC table, if there is an inspection corresponding to this project displays the most recent score.",
+        "required_in_source": false,
+        "source_name": "most_recent_reac_score_num",
+        "sql_name": "most_recent_reac_score_num",
+        "type": "integer"
+      }, 
+      {
+        "display_name": "Most Recent REAC Score Date",
+        "display_text": "From the matching record in the reac_score table",
+        "required_in_source": false,
+        "source_name": "most_recent_reac_score_date",
+        "sql_name": "most_recent_reac_score_date",
+        "type": "date"
+      }, 
+      {
+        "display_name": "Most Recent REAC Score ID",
+        "display_text": "ID in the reac_score to uniquely identify the record corresponding to the Most Recent REAC Score",
+        "required_in_source": false,
+        "source_name": "most_recent_reac_score_id",
+        "sql_name": "most_recent_reac_score_id",
+        "type": "text"
+      }, 
+      {
         "display_name": "Unique Data ID",
         "display_text": "Identifies which source file this record came from",
         "required_in_source": false,


### PR DESCRIPTION
Adds the functionality to have calculated fields in project table during updates of the database. Implements this for the 'most recent reac score'. Relevant to both #425 and #430. 

My only concern so far is maintaining the messy SQL statements required to extract the relevant data from the partner tables. I tried to implement the automap function so that I could try to use SQLAlchemy syntax, but I didn't see a way to then actually use that to do the stuff I wanted to. Straight SQL seemed easier to implement. 

At a minimum we could break each field update into a separate method - at the moment I have comments to designate sections of the _populate_calculated_project_fields code, but the could be methods that are listed out one by one just to break up teh code a bit. 

@jkwening especially your review would be appreciated!

I have deployed this to the Code for DC RDS instance - we'll be switching over to that one for V2 launch, though for the moment I'm using both the EC2 and RDS instances as sandboxes for testing our changes so we don't break the live site with stuff like this. Contact me for the connect string to add to secrets.json to check it out. 