### PR TITLE
Refactor continuous filter

### DIFF
--- a/docs/tool/js/core/housing-insights.js
+++ b/docs/tool/js/core/housing-insights.js
@@ -49,26 +49,42 @@ function StateModule() {
 
     function setState(key,value) { // making all state properties arrays so that previous value is held on to
                                    // current state to be accessed as state[key][0].
-        if ( state[key] === undefined ) {
+        var stateIsNew = (state[key] === undefined);
+
+        
+
+        if ( stateIsNew ) {
             state[key] = [value];
             PubSub.publish(key, value);
-            console.log('STATE CHANGE', key, value);
-        } else if ( state[key][0] !== value ) { // only for when `value` is a string or number. doesn't seem
-                                                // to cause an issue when value is an object, but it does duplicate
-                                                // the state. i.e. key[0] and key[1] will be equivalent. avoid that
-                                                // with logic before making the setState call.
-            state[key].unshift(value);
-            PubSub.publish(key, value);
-            console.log('STATE CHANGE', key, value);
-            if ( state[key].length > 2 ) {
-                state[key].length = 2;
-            }
+            console.log('STATE CREATED', key, value);
+
         } else {
-            //TODO do we want for there to be another 'announceState' method that publishes every time it fires, even if the value remains the same??
-            console.log("State value is the same as previous:", key, value);
+            //If it's a string or array and values are the same, stateChanged=False+
+            var stateChanged = true;
+            if (typeof value === 'string') {
+                stateChanged = (state[key][0] !== value)
+            } else if (Array.isArray(value) && Array.isArray(state[key][0])) {
+                stateChanged = !value.compare(state[key][0])
+            } else {
+                stateChanged = true; //assume it's changed if we can't verify
+            }
+
+            //Only publish if we've changed state
+            if (stateChanged ) { 
+                state[key].unshift(value);
+                PubSub.publish(key, value);
+
+                console.log('STATE CHANGE', key, value);
+                if ( state[key].length > 2 ) {
+                    state[key].length = 2;
+                }
+            } else {
+                //TODO do we want for there to be another 'announceState' method that publishes every time it fires, even if the value remains the same??
+                console.log("STATE UNCHANGED, NO PUB:", key, value);
+            }
         }
-        
     }
+
     function clearState(key) {
         delete state[key];
          PubSub.publish('clearState', key);
@@ -362,6 +378,20 @@ var getFieldFromMeta = function(table,sql_name){
     this.splice(new_index, 0, this.splice(old_index, 1)[0]);
     return this; // for testing purposes
 };
+
+//array.compare(otherArray) //HT https://stackoverflow.com/questions/6229197/how-to-know-if-two-arrays-have-the-same-values
+Array.prototype.compare = function(testArr) {
+    if (this.length != testArr.length) return false;
+    if (this.length === 0 && testArr.length === 0) return true;
+    console.log("in compare");
+    console.log(this);
+    for (var i = 0; i < testArr.length; i++) {
+        if (this[i] !== testArr[i]) {
+            return false;
+        }
+    }
+    return true;
+}
 
 // HELPER String.hashCode()
 

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -68,24 +68,23 @@ var router = {
         document.getElementById('loading-state-screen').style.display = 'block';
     },
     decodeState: function(){
+        console.log("decoding state from URL");
         var stateArray = window.location.hash.replace('#/HI/','').split('&');
         stateArray.forEach(function(each){
             var eachArray = each.split('=');
             var dataChoice = dataChoices.find(function(obj){
                 return obj.short_name === eachArray[0];
             });
+            var filterControlObj = filterView.filterControlsDict[dataChoice.short_name]
+
             if ( dataChoice.component_type === 'continuous' ) {
                 var separator = eachArray[1].indexOf('-') !== -1 ? '-' : '_';
                 var values = eachArray[1].split(separator);
-                // set the values of the corresponding textInput
-                filterView.filterInputs[dataChoice.short_name].setValues([['min', +values[0]]],[['max', +values[1]]]);
-                if ( separator === '_') { // encoded nullShown == false
-                    document.querySelector('[name="showNulls-' + dataChoice.source + '"]').checked = false;
-                    setState('nullsShown.' + dataChoice.source, false); // this will eventually trigger the callback
-                                                                        // so no need to trigger it here
-                } else { // call the corresponding textInput's callback
-                    filterView.filterInputs[dataChoice.short_name].callback();
-                }
+                var min = +values[0]
+                var max = +values[1]
+                var nullsShown = separator === '_' ? false : true;
+                
+                filterControlObj.set(min,max,nullsShown);
                 
             }
             if ( dataChoice.component_type === 'categorical' ){

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -113,8 +113,11 @@ var filterView = {
 
     },
     filterControls: [],
+    filterControlsDict: {},
     filterControl: function(component){
+        //TODO refactor to use Dict instead of list version. Keeping both for now
         filterView.filterControls.push(this);
+        filterView.filterControlsDict[component.short_name] = this;
         this.component = component;
     },
     nullValuesToggle: function(component, filterControl){
@@ -419,7 +422,9 @@ var filterView = {
                 });
 
                 //Bind the slider values to the textboxes
-                textBoxes.setValues([['min', unencoded[0]]],[['max', unencoded[1]]]);
+                var min = unencoded[0]
+                var max = unencoded[1]
+                textBoxes.setValues([['min', min]],[['max', max]]);
 
                 //Set the filterValues state
                 if(doesItSetState){
@@ -456,12 +461,23 @@ var filterView = {
                                    // way it works. as if otherwise it fires before toggle.triggerToggleWithoutClick finished
                 setState(specific_state_code, []);
             });
-        }
+        };
 
         this.isTouched = function(){
             var returnVals = textBoxes.returnValues();
             return returnVals.min.min !== minDatum || returnVals.max.max !== maxDatum || this.nullsShown === false;
-        }
+        };
+
+        this.set = function(min,max,nullValue){
+
+            textBoxes.setValues([['min', min]],[['max', max]]);
+            slider.noUiSlider.set([min, max]);
+            //TODO set toggle in better way
+            document.querySelector('[name="showNulls-' + c.source + '"]').checked = nullValue;
+
+            setState('filterValues.' + c.source,[min,max,nullValue]);
+        };
+
 
         // At the very end of setup, set the 'nullsShown' state so that it's available for
         // use by code in filter.js that iterates through filterValues.


### PR DESCRIPTION
Our filter components, and their links to the state module, have gotten complicated. The continuous filter is the most complicated, as it has text boxes, null checkboxes, sliders, and associated states for all of these. 

I'm trying to refactor this code to make it a bit easier to follow, in preparation for (manually) pulling in the code for #444. This PR is mostly rearranging the order of the code in the continuousfiltercontrol setup function so that code that is related to each other appears side by side, plus the addition of some code comments. Making this a separate PR so that the manual additions of #444 are clearly differentiated from this rearrangement.