### PR TITLE
392 zone filters + continuous and nulls refactor

### DIFF
--- a/docs/tool/js/core/housing-insights.js
+++ b/docs/tool/js/core/housing-insights.js
@@ -57,7 +57,7 @@ function StateModule() {
             state[key] = [value];
             PubSub.publish(key, value);
             console.log('STATE CREATED', key, value);
-            console.trace("Stack trace for state " + key)
+            console.trace("Stack trace for state " + key);
 
         } else {
             //If it's a string or array and values are the same, stateChanged=False+
@@ -76,14 +76,14 @@ function StateModule() {
                 PubSub.publish(key, value);
 
                 console.log('STATE CHANGE', key, value);
-                console.trace("Stack trace for state " + key)
+                console.trace("Stack trace for state " + key);
                 if ( state[key].length > 2 ) {
                     state[key].length = 2;
                 }
             } else {
                 //TODO do we want for there to be another 'announceState' method that publishes every time it fires, even if the value remains the same??
                 console.log("STATE UNCHANGED, NO PUB:", key, value);
-                console.trace("Stack trace for state " + key)
+                console.trace("Stack trace for state " + key);
             }
         }
         console.groupEnd()

--- a/docs/tool/js/core/housing-insights.js
+++ b/docs/tool/js/core/housing-insights.js
@@ -52,11 +52,12 @@ function StateModule() {
         var stateIsNew = (state[key] === undefined);
 
         
-
+        console.groupCollapsed("setState:", key, value)
         if ( stateIsNew ) {
             state[key] = [value];
             PubSub.publish(key, value);
             console.log('STATE CREATED', key, value);
+            console.trace("Stack trace for state " + key)
 
         } else {
             //If it's a string or array and values are the same, stateChanged=False+
@@ -75,14 +76,17 @@ function StateModule() {
                 PubSub.publish(key, value);
 
                 console.log('STATE CHANGE', key, value);
+                console.trace("Stack trace for state " + key)
                 if ( state[key].length > 2 ) {
                     state[key].length = 2;
                 }
             } else {
                 //TODO do we want for there to be another 'announceState' method that publishes every time it fires, even if the value remains the same??
                 console.log("STATE UNCHANGED, NO PUB:", key, value);
+                console.trace("Stack trace for state " + key)
             }
         }
+        console.groupEnd()
     }
 
     function clearState(key) {

--- a/docs/tool/js/core/housing-insights.js
+++ b/docs/tool/js/core/housing-insights.js
@@ -49,26 +49,42 @@ function StateModule() {
 
     function setState(key,value) { // making all state properties arrays so that previous value is held on to
                                    // current state to be accessed as state[key][0].
-        if ( state[key] === undefined ) {
+        var stateIsNew = (state[key] === undefined);
+
+        
+
+        if ( stateIsNew ) {
             state[key] = [value];
             PubSub.publish(key, value);
-            console.log('STATE CHANGE', key, value);
-        } else if ( state[key][0] !== value ) { // only for when `value` is a string or number. doesn't seem
-                                                // to cause an issue when value is an object, but it does duplicate
-                                                // the state. i.e. key[0] and key[1] will be equivalent. avoid that
-                                                // with logic before making the setState call.
-            state[key].unshift(value);
-            PubSub.publish(key, value);
-            console.log('STATE CHANGE', key, value);
-            if ( state[key].length > 2 ) {
-                state[key].length = 2;
-            }
+            console.log('STATE CREATED', key, value);
+
         } else {
-            //TODO do we want for there to be another 'announceState' method that publishes every time it fires, even if the value remains the same??
-            console.log("State value is the same as previous:", key, value);
+            //If it's a string or array and values are the same, stateChanged=False+
+            var stateChanged = true;
+            if (typeof value === 'string') {
+                stateChanged = (state[key][0] !== value)
+            } else if (Array.isArray(value) && Array.isArray(state[key][0])) {
+                stateChanged = !value.compare(state[key][0])
+            } else {
+                stateChanged = true; //assume it's changed if we can't verify
+            }
+
+            //Only publish if we've changed state
+            if (stateChanged ) { 
+                state[key].unshift(value);
+                PubSub.publish(key, value);
+
+                console.log('STATE CHANGE', key, value);
+                if ( state[key].length > 2 ) {
+                    state[key].length = 2;
+                }
+            } else {
+                //TODO do we want for there to be another 'announceState' method that publishes every time it fires, even if the value remains the same??
+                console.log("STATE UNCHANGED, NO PUB:", key, value);
+            }
         }
-        
     }
+
     function clearState(key) {
         delete state[key];
          PubSub.publish('clearState', key);
@@ -362,6 +378,20 @@ var getFieldFromMeta = function(table,sql_name){
     this.splice(new_index, 0, this.splice(old_index, 1)[0]);
     return this; // for testing purposes
 };
+
+//array.compare(otherArray) //HT https://stackoverflow.com/questions/6229197/how-to-know-if-two-arrays-have-the-same-values
+Array.prototype.compare = function(testArr) {
+    if (this.length != testArr.length) return false;
+    if (this.length === 0 && testArr.length === 0) return true;
+    console.log("in compare");
+    console.log(this);
+    for (var i = 0; i < testArr.length; i++) {
+        if (this[i] !== testArr[i]) {
+            return false;
+        }
+    }
+    return true;
+}
 
 // HELPER String.hashCode()
 

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -7,7 +7,6 @@ var router = {
         if ( router.isFilterInitialized ) return;
         setSubs([
             ['filterValues', router.pushFilter]
-    //        ['nullsShown', router.nullsHandler] // triggered when the nullsShown check is toggled. not when a filter range is adjusted
         ]);        
         router.isFilterInitialized = true;
         if ( router.hasInitialFilterState ) router.decodeState();
@@ -42,15 +41,16 @@ var router = {
             var dataChoice = dataChoices.find(function(obj){
                 return key.split('.')[1] === obj.source;
             });
-            var separator = getState()['nullsShown.' + dataChoice.source] && getState()['nullsShown.' + dataChoice.source][0] ? '-' : '_';
             
             if ( dataChoice.component_type === 'continuous' ) {
+                var separator = router.stateObj[key] && router.stateObj[key][2] ? '-' : '_';
                 paramsArray.push(dataChoice.short_name + '=' + Math.round(router.stateObj[key][0]) + separator + Math.round(router.stateObj[key][1])); 
             }
             if ( dataChoice.component_type === 'categorical' ){
                 paramsArray.push( dataChoice.short_name + '=' + router.stateObj[key].join('+'));
             }
             if ( dataChoice.component_type === 'date' ){
+                var separator = router.stateObj[key] && router.stateObj[key][2] ? '-' : '_';
                 var dateStrings = [];
                 for ( var i = 0; i < 2; i++ ){ // i < 2 bc index 2 is true/false of nullsShown
                     var date = router.stateObj[key][i].getDate();
@@ -94,7 +94,10 @@ var router = {
             if ( dataChoice.component_type === 'date' ){
                 // handle decoding for date type filter here
                 var separator = eachArray[1].indexOf('-') !== -1 ? '-' : '_';
+                var nullsShown = separator === '_' ? false : true;
                 var values = eachArray[1].split(separator);
+
+                //Set the values on the input boxes
                 filterView.filterInputs[dataChoice.short_name].setValues(
                     [
                         [ 'year',  values[0].match(/\d{4}/)[0] ],
@@ -107,13 +110,10 @@ var router = {
                         [ 'day',   values[1].match(/d(\d+)/)[1]]
                     ]
                 );
-                 if ( separator === '_') { // encoded nullShown == false
-                    document.querySelector('[name="showNulls-' + dataChoice.source + '"]').checked = false;
-                    setState('nullsShown.' + dataChoice.source, false); // this will eventually trigger the callback
-                                                                        // so no need to trigger it here
-                } else { // call the corresponding textInput's callback
-                    filterView.filterInputs[dataChoice.short_name].callback();
-                }
+                document.querySelector('[name="showNulls-' + dataChoice.source + '"]').checked = nullsShown;
+                
+                //Commit the values using callback(), which will update slider to match. 
+                filterView.filterInputs[dataChoice.short_name].callback();
             }
 
         });
@@ -136,26 +136,6 @@ var router = {
     hashChangeHandler: function(){
         controller.goBack();
     },
-    nullsHandler: function (msg,data) { // for handling when a nullsShown checkbox is toggled. needs to grab values of the filter
-        var component = msg.split('.')[1];
-        var dataChoice = dataChoices.find(function(each){
-            return each.source === component;
-        });
-        var type = dataChoice.component_type;
-        var shortName = dataChoice.short_name;
-        if ( type === 'categorical' ) {
-            // i think this is a null set; no unknowns in categorical filters
-        }
-        if ( type === 'continuous' ) {
-
-        }
-        if ( type === 'date' ) {
-
-        }
-        if ( type === 'location' ) {
-            // to come
-        }
-    }
 
 };
 window.onhashchange = function() {

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -68,24 +68,23 @@ var router = {
         document.getElementById('loading-state-screen').style.display = 'block';
     },
     decodeState: function(){
+        console.log("decoding state from URL");
         var stateArray = window.location.hash.replace('#/HI/','').split('&');
         stateArray.forEach(function(each){
             var eachArray = each.split('=');
             var dataChoice = dataChoices.find(function(obj){
                 return obj.short_name === eachArray[0];
             });
+            var filterControlObj = filterView.filterControlsDict[dataChoice.short_name]
+
             if ( dataChoice.component_type === 'continuous' ) {
                 var separator = eachArray[1].indexOf('-') !== -1 ? '-' : '_';
                 var values = eachArray[1].split(separator);
-                // set the values of the corresponding textInput
-                filterView.filterInputs[dataChoice.short_name].setValues([['min', +values[0]]],[['max', +values[1]]]);
-                if ( separator === '_') { // encoded nullShown == false
-                    document.querySelector('[name="showNulls-' + dataChoice.source + '"]').checked = false;
-                    setState('nullsShown.' + dataChoice.source, false); // this will eventually trigger the callback
-                                                                        // so no need to trigger it here
-                } else { // call the corresponding textInput's callback
-                    filterView.filterInputs[dataChoice.short_name].callback();
-                }
+                var min = +values[0]
+                var max = +values[1]
+                var nullsShown = separator === '_' ? false : true;
+                
+                filterControlObj.set(min,max,nullsShown);
                 
             }
             if ( dataChoice.component_type === 'categorical' ){

--- a/docs/tool/js/util/filter.js
+++ b/docs/tool/js/util/filter.js
@@ -90,25 +90,28 @@ var filterUtil = {
 			}
 
 			if (component['component_type']== 'date') {
-                
-                workingData = workingData.filter(function(d){
-                   // Refer to the third element of the most recent value of
-                   // filterValues, which is a boolean indicating whether
-                   // null values will be shown.
-                    if(d[key] === null){
-                        return filterValues[key][0][2];
-                    }
+                if (filterValues[key][0].length == 0){
+                    // don't filter because the filter has been removed.
+                    // The length would be '1' because nullsShown is always included.
+                } else {
+                    workingData = workingData.filter(function(d){
+                       // Refer to the third element of the most recent value of
+                       // filterValues, which is a boolean indicating whether
+                       // null values will be shown.
+                        if(d[key] === null){
+                            return filterValues[key][0][2];
+                        }
 
-                    // If the filter is 'empty' and the value isn't null,
-                    // show the project.
-                    if(filterValues[key][0].length === 0){
-                        return true;
-                    }
-                    
-                    return d[key].valueOf() >= filterValues[key][0][0].valueOf() 
-                        && d[key].valueOf() <= filterValues[key][0][1].valueOf();
-                });
-
+                        // If the filter is 'empty' and the value isn't null,
+                        // show the project.
+                        if(filterValues[key][0].length === 0){
+                            return true;
+                        }
+                        
+                        return d[key].valueOf() >= filterValues[key][0][0].valueOf() 
+                            && d[key].valueOf() <= filterValues[key][0][1].valueOf();
+                    });
+                }
 			}
 
 			if (component['component_type'] == 'categorical') {

--- a/docs/tool/js/util/filter.js
+++ b/docs/tool/js/util/filter.js
@@ -72,12 +72,13 @@ var filterUtil = {
 		for (key in filterValues) { // iterate through registered filters
 			
             //need to get the matching component out of a list of objects
-            var component = filterView.components.filter(function(obj) {
+            var component = dataChoices.filter(function(obj) {
               return obj.source == key;
             });
-            component = component[0] //the most recent filter (current and previous are returned in a list)
+            component = component[0]
+
                         
-			if (component['component_type'] == 'continuous') { //filter data for a 'continuous' filter
+			if (component['component_type'] == 'continuous') {
                 
                 if (filterValues[key][0].length == 0){
                     // don't filter because the filter has been removed.
@@ -86,17 +87,19 @@ var filterUtil = {
                     //javascript rounding is weird
                     var decimalPlaces = component['data_type'] == 'integer' ? 0 : 2 //ternary operator
                     var min = Number(Math.round(filterValues[key][0][0]+'e'+decimalPlaces) +'e-'+decimalPlaces);
-                    var max =Number(Math.round(filterValues[key][0][1]+'e'+decimalPlaces)+'e-'+decimalPlaces);
-
+                    var max = Number(Math.round(filterValues[key][0][1]+'e'+decimalPlaces)+'e-'+decimalPlaces);
+                    //If it's a zone-level data set, need to choose the right column
+                    var modifier = component.data_level == 'zone' ? ("_" + getState()['mapLayer'][0]) : '' 
+                    
                     //filter it
                     workingData = workingData.filter(function(d){
                     // Refer to the third element of the most recent value of
                     // filterValues, which is a boolean indicating whether
                     // null values will be shown.
-                        if(d[key] === null){
+                        if(d[(key + modifier)] === null){
                             return nullsShown[key];
                         }
-    					return (d[key] >= min && d[key] <= max);
+    					return (d[(key + modifier)] >= min && d[(key + modifier)] <= max);
     				});
                 };
 			}

--- a/docs/tool/js/util/filter.js
+++ b/docs/tool/js/util/filter.js
@@ -54,20 +54,7 @@ var filterUtil = {
 	filterData: function(){
         
     	var workingData = model.dataCollection['filterData'].objects; 
-        var nullsShown = filterUtil.getNullsShown(); // creates object with nullShown state ofall filters
         var filterValues = filterUtil.getFilterValues();
-
-        for (var key in nullsShown){
-            var component = (filterView.components.filter(function(obj){
-                return obj.source == key;
-            }))[0];
-
-            if (component.component_type == 'continuous' || component.component_type == 'date'){
-                workingData = workingData.filter(function(d){
-                    return d[key] !== null || nullsShown[key][0]; // nullsShown[key][0] is true or fals; if false returns when d[key] is not null
-                });
-            }
-        }
 
 		for (key in filterValues) { // iterate through registered filters
 			
@@ -88,16 +75,14 @@ var filterUtil = {
                     var decimalPlaces = component['data_type'] == 'integer' ? 0 : 2 //ternary operator
                     var min = Number(Math.round(filterValues[key][0][0]+'e'+decimalPlaces) +'e-'+decimalPlaces);
                     var max = Number(Math.round(filterValues[key][0][1]+'e'+decimalPlaces)+'e-'+decimalPlaces);
+
                     //If it's a zone-level data set, need to choose the right column
                     var modifier = component.data_level == 'zone' ? ("_" + getState()['mapLayer'][0]) : '' 
                     
                     //filter it
                     workingData = workingData.filter(function(d){
-                    // Refer to the third element of the most recent value of
-                    // filterValues, which is a boolean indicating whether
-                    // null values will be shown.
                         if(d[(key + modifier)] === null){
-                            return nullsShown[key];
+                            return filterValues[key][0][2]; //third element in array is true/false for nulls shown
                         }
     					return (d[(key + modifier)] >= min && d[(key + modifier)] <= max);
     				});
@@ -111,7 +96,7 @@ var filterUtil = {
                    // filterValues, which is a boolean indicating whether
                    // null values will be shown.
                     if(d[key] === null){
-                        return nullsShown[key];
+                        return filterValues[key][0][2];
                     }
 
                     // If the filter is 'empty' and the value isn't null,

--- a/docs/tool/js/views/dataChoices.js
+++ b/docs/tool/js/views/dataChoices.js
@@ -190,6 +190,7 @@
             "style": "percent",
             "short_name": "sm"
         },
+        /*
         {
             "source": "fraction_black",
             "display_name": "ACS: Fraction Black",
@@ -202,6 +203,7 @@
             "style": "percent",
             "short_name": "fb"
         },
+        */
         {
             "source": "fraction_foreign",
             "display_name": "ACS: Fraction Foreign",

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -113,8 +113,11 @@ var filterView = {
 
     },
     filterControls: [],
+    filterControlsDict: {},
     filterControl: function(component){
+        //TODO refactor to use Dict instead of list version. Keeping both for now
         filterView.filterControls.push(this);
+        filterView.filterControlsDict[component.short_name] = this;
         this.component = component;
     },
     nullValuesToggle: function(component, filterControl){
@@ -419,7 +422,9 @@ var filterView = {
                 });
 
                 //Bind the slider values to the textboxes
-                textBoxes.setValues([['min', unencoded[0]]],[['max', unencoded[1]]]);
+                var min = unencoded[0]
+                var max = unencoded[1]
+                textBoxes.setValues([['min', min]],[['max', max]]);
 
                 //Set the filterValues state
                 if(doesItSetState){
@@ -456,12 +461,23 @@ var filterView = {
                                    // way it works. as if otherwise it fires before toggle.triggerToggleWithoutClick finished
                 setState(specific_state_code, []);
             });
-        }
+        };
 
         this.isTouched = function(){
             var returnVals = textBoxes.returnValues();
             return returnVals.min.min !== minDatum || returnVals.max.max !== maxDatum || this.nullsShown === false;
-        }
+        };
+
+        this.set = function(min,max,nullValue){
+
+            textBoxes.setValues([['min', min]],[['max', max]]);
+            slider.noUiSlider.set([min, max]);
+            //TODO set toggle in better way
+            document.querySelector('[name="showNulls-' + c.source + '"]').checked = nullValue;
+
+            setState('filterValues.' + c.source,[min,max,nullValue]);
+        };
+
 
         // At the very end of setup, set the 'nullsShown' state so that it's available for
         // use by code in filter.js that iterates through filterValues.

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -317,12 +317,29 @@ var filterView = {
         
         //Find initial values for controls
         this.nullsShown = true;
-        var allDataValuesForThisSource = model.dataCollection.filterData.objects.map(function(item){
-            return item[c.source];
-        });
-        var minDatum = d3.min(allDataValuesForThisSource) || 0;
-        var maxDatum = d3.max(allDataValuesForThisSource) || 1;
-        var stepCount = Math.max(1, parseInt((maxDatum - minDatum)/500));
+
+        this.calculateParams = function(){
+            var modifier = c.data_level == 'zone' ? ("_" + getState()['mapLayer'][0]) : '' 
+            var data_field = c.source + modifier
+            console.log(data_field);
+            var allDataValuesForThisSource = model.dataCollection.filterData.objects.map(function(item){
+                return item[data_field];
+            });
+            this.minDatum = d3.min(allDataValuesForThisSource) || 0;
+            this.maxDatum = d3.max(allDataValuesForThisSource) || 1;
+            this.stepCount = Math.max(1, parseInt((this.maxDatum - this.minDatum)/500));
+
+            if (c.style === "percent") {
+                console.log("formatted as percent")
+                this.minDatum = Math.round(this.minDatum * 100) / 100;
+                this.maxDatum = Math.round(this.maxDatum * 100) / 100;
+            } else { //"number", "money"
+                this.minDatum = Math.round(this.minDatum);
+                this.maxDatum = Math.round(this.maxDatum);
+            }
+        }
+        
+        this.calculateParams();
 
         //Make the slider itself
         var slider = contentContainer.append("div")
@@ -332,14 +349,14 @@ var filterView = {
 
         slider = document.getElementById(c.source); //d3 select method wasn't working, override variable
         noUiSlider.create(slider, {
-            start: [minDatum, maxDatum],
+            start: [this.minDatum, this.maxDatum],
             connect: true,
             tooltips: [ false, false ], //using textboxes instead
             range: {
-                'min': minDatum,
-                'max': maxDatum
+                'min': this.minDatum,
+                'max': this.maxDatum
             },
-            step: stepCount
+            step: this.stepCount
         });
         
         ////////////////////////
@@ -349,8 +366,8 @@ var filterView = {
         //Create object instance
         var textBoxes = new filterView.filterTextInput( 
             c,        
-            [['min', minDatum]],
-            [['max', maxDatum]]
+            [['min', this.minDatum]],
+            [['max', this.maxDatum]]
         );
         filterView.filterInputs[this.component.short_name] = textBoxes;
  

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -13,10 +13,10 @@ var filterView = {
                 ['sidebar', filterView.toggleSidebar],
                 ['subNav', filterView.toggleSubNavButtons],
                 ['filterValues', filterView.indicateActivatedFilters],
-                ['nullsShown', filterView.indicateActivatedFilters],
+                //['nullsShown', filterView.indicateActivatedFilters],
                 ['anyFilterActive', filterView.handleFilterClearance],
                 ['filterValues', filterView.addClearPillboxes],
-                ['nullsShown', filterView.addClearPillboxes],
+                //['nullsShown', filterView.addClearPillboxes],
                 ['dataLoaded.filterData', filterView.formatFilterDates],
                 ['filterDatesFormatted', filterView.buildFilterComponents],
                 ['subNavExpanded.right', filterView.expandSidebar],
@@ -352,7 +352,7 @@ var filterView = {
             .classed("slider",true)
             .attr("id",c.source);
 
-        this.slider = document.getElementById(c.source); //d3 select method wasn't working, override variable
+        this.slider = document.getElementById(c.source);
         
         noUiSlider.create(this.slider, {
             start: [this.minDatum, this.maxDatum],
@@ -487,7 +487,7 @@ var filterView = {
 
         this.isTouched = function(){
             var returnVals = textBoxes.returnValues();
-            return returnVals.min.min !== minDatum || returnVals.max.max !== maxDatum || this.nullsShown === false;
+            return returnVals.min.min !== this.minDatum || returnVals.max.max !== this.maxDatum || this.nullsShown === false;
         };
 
         this.set = function(min,max,nullValue){


### PR DESCRIPTION
This pull request includes a variety of changes to the filterControl elements, primarily for continuous controls but also for date controls, and to the connected filter.js, router.js. Note that this PR also includes #448 which did some simple rearrangment of the continuous filter. Included:

- Any continuous control can have its min/max values reset at any point. 
- Zone-based continuous filters have their values cleared and min/max values reset whenever the zone type is changed. 
- Rearranges how values of the UI components (checkbox, textbox, slider) are bound together. If adjusting one of the UI components, the new state is determined by what is currently in the other UI components. This way if the internal state somehow gets out of sync with the UI state, it will self correct whenever a user uses any of the UI for that filter (see bugs resolved below)
- Stores all the UI components on the filterControl itself so they can be accessed by other code. 
- Removes the state of `nullsShown.<source>` in favor of using the 3rd value of the `filterValues.` state array (i.e. `[min,max,nullValue]`). The URL encoding code already added this to the state, which was duplicative, and we want the checkboxes to cause the same reactions in the UI as the sliders re: pillboxes etc. - @ptgott created the nullsShown state to separate the checkboxes from the code that executes filters, but that turned out to not be the desired behavior and maintaining two separate states was more complexity. 

This also fixes a few bugs that existed in the current dev branch:
- When loading a saved state, the checkbox for nulls could get unsynced from the values when includenulls was false, meaning the checkbox showed the opposite of what the state was. (found during dev, no issue created)
- Similar bug when executing filter updates in a certain order as described in bullet 2 of #442 

Additional bonus feature:
- Changes how the setState() command logs to the console. It now prints a grouped log that includes a stack trace, so coders can see which file initiated the new state for easier debugging. 