### PR TITLE
WIP -   437 building permit update

### DIFF
--- a/python/housinginsights/ingestion/Cleaners.py
+++ b/python/housinginsights/ingestion/Cleaners.py
@@ -382,6 +382,22 @@ class CleanerBase(object, metaclass=ABCMeta):
         else:
             return row
 
+    def filter_row_by(self, row, criteria=None):
+        """
+        Returns empty dict for rows that meet filter criteria.
+
+        :param row: the row to be verified
+        :param criteria: dict where each key is a field in the row dict and the
+        values for which you want filter for. The values for each key should
+        be a list of values you don't want to get loaded into the database.
+        """
+        if criteria is not None:
+            for key in criteria:
+                if row[key] in criteria[key]:
+                    return dict()
+
+        return row
+
 
 #############################################
 # Custom Cleaners
@@ -391,7 +407,8 @@ class CleanerBase(object, metaclass=ABCMeta):
 # TODO: map to specific cleaner methods including option to pass custom methods
 
 class GenericCleaner(CleanerBase):
-    def clean(self,row, row_num=None):
+    def clean(self, row, row_num=None):
+        row = self.replace_nulls(row, null_values=['N', 'NA', '', None])
         return row
 
 
@@ -618,4 +635,16 @@ class ZillowCleaner(CleanerBase):
         '121693', '121695', '121702', '121704', '121709', '121718', '121727', '121729', '121736', '121743', '121745', '403135', '403134', 
         '121816', '121815', '403139', '403116', '273767', '403478', '273489', '268811', '121808', '121807', '121806', '121791', '121788', 
         '121774', '121772', '121754', '121759', '121761', '121777', '121779', '121786', '268815', '268831', '272818', '273159', '275465', 
-        '403115', '403481', '403483', '403490', '403492', '403499', '403501', '403506', '121718', '121788', '403505']       
+        '403115', '403481', '403483', '403490', '403492', '403499', '403501', '403506', '121718', '121788', '403505']
+
+
+class MarCleaner(CleanerBase):
+    def clean(self, row, row_num=None):
+        criteria = {
+            'TYPE_': ['PLACE']
+        }
+        row = self.filter_row_by(row, criteria)
+        if not row:  # skip other cleaning steps if filtered out
+            return None
+        row = self.replace_nulls(row, null_values=['N', 'NA', '', None])
+        return row

--- a/python/housinginsights/ingestion/LoadData.py
+++ b/python/housinginsights/ingestion/LoadData.py
@@ -22,6 +22,10 @@ import os
 import logging
 import argparse
 import json
+import concurrent.futures
+from time import time, sleep
+from requests.packages.urllib3.exceptions import NewConnectionError
+from requests.packages.urllib3.exceptions import MaxRetryError
 
 from sqlalchemy import Table, Column, Integer, String, MetaData, Numeric
 from datetime import datetime
@@ -940,21 +944,78 @@ class LoadData(object):
         # if it doesn't have a 'loaded' status in the database manifest
         if csv_reader.should_file_be_loaded(sql_manifest_row=sql_manifest_row):
             print("  Cleaning...")
-            meta_only_fields = self._get_meta_only_fields(
-                table_name=table_name, data_fields=csv_reader.keys)
-            for idx, data_row in enumerate(csv_reader):
-                data_row.update(meta_only_fields)  # insert other field dict
+            start_time = time()
+            # meta_only_fields = self._get_meta_only_fields(
+            #     table_name=table_name, data_fields=csv_reader.keys)
+            # # TODO - concurrency can be handled here: row at a time
+            # # TODO - while cleaning one row, start cleaning the next
+            # # TODO - once cleaning is done, write row to psv file
+            # # TODO - consider using queue: once empty update db with psv data
+            # for idx, data_row in enumerate(csv_reader):
+            #     data_row.update(meta_only_fields)  # insert other field dict
+            #     clean_data_row = cleaner.clean(data_row, idx)
+            #     if clean_data_row is not None:
+            #         csv_writer.write(clean_data_row)
+
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=100) as executor:
+                future_data = {executor.submit(
+                    self._clean_data, idx, data_row, cleaner, table_name,
+                    csv_reader.keys): (
+                    idx, data_row) for idx, data_row in enumerate(csv_reader)}
+                for future in concurrent.futures.as_completed(future_data):
+                    clean_data_row = future.result()
+                    if clean_data_row is not None:
+                        csv_writer.write(clean_data_row)
+
+                csv_writer.close()
+
+                # write the data to the database
+                self._update_database(sql_interface=sql_interface)
+
+                if not self._keep_temp_files:
+                    csv_writer.remove_file()
+                end_time = time()
+                print("\nRun time= %s" % (end_time - start_time))
+
+            # csv_writer.close()
+            #
+            # # write the data to the database
+            # self._update_database(sql_interface=sql_interface)
+            #
+            # if not self._keep_temp_files:
+            #     csv_writer.remove_file()
+            # end_time = time()
+            # print("\nRun time= %s" % (end_time - start_time))
+
+    def _clean_data(self, idx, data_row, cleaner, table_name, data_fields):
+        """
+        Helper function that actually does the cleaning processing of each
+        row in the raw data file. To improve performance, each row is
+        processess currently by n number of threads determined in
+        _load_single_file method.
+
+        :param idx: the index of the data row
+        :param data_row: the data row to be processed
+        :param cleaner: an object representing the cleaner class to be used
+        :param table_name: the name of the table the data should go in
+        :param data_fields: the column headers required in the database
+        :return: the processed clean data row
+        """
+        meta_only_fields = self._get_meta_only_fields(
+            table_name=table_name, data_fields=data_fields)
+        data_row.update(meta_only_fields)  # insert other field dict keys
+
+        # handle connection timeouts by pausing then trying again
+        while True:
+            try:
                 clean_data_row = cleaner.clean(data_row, idx)
-                if clean_data_row is not None:
-                    csv_writer.write(clean_data_row)
+                break
+            except Exception:
+                logging.warning("_clean_data(): %s" % data_row)
+                sleep(1)
 
-            csv_writer.close()
-
-            # write the data to the database
-            self._update_database(sql_interface=sql_interface)
-
-            if not self._keep_temp_files:
-                csv_writer.remove_file()
+        return clean_data_row
 
     def _update_database(self, sql_interface):
         """

--- a/python/housinginsights/ingestion/SQLWriter.py
+++ b/python/housinginsights/ingestion/SQLWriter.py
@@ -154,7 +154,7 @@ class HISql(object):
         # TODO make sure data is synced or appended properly
         sql_manifest_row = self.get_sql_manifest_row(db_conn=conn,
                                                      close_conn=False)
-        if sql_manifest_row is None:
+        if sql_manifest_row is not None:
             logging.info("  deleting existing manifest row for {}".format(
                 self.unique_data_id))
             delete_command = \

--- a/python/housinginsights/ingestion/SQLWriter.py
+++ b/python/housinginsights/ingestion/SQLWriter.py
@@ -130,7 +130,7 @@ class HISql(object):
         
         #TODO need to find out what types of expected errors might actually occur here  
         #For now, assume that SQLAlchemy will raise a programmingerror
-        except (ProgrammingError, DataError) as e:
+        except (ProgrammingError, DataError, TypeError) as e:
             trans.rollback()
 
             logging.warning("  FAIL: something went wrong loading {}".format(self.unique_data_id))

--- a/python/housinginsights/ingestion/make_draft_json.py
+++ b/python/housinginsights/ingestion/make_draft_json.py
@@ -18,8 +18,6 @@ python_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                                os.pardir, os.pardir))
 sys.path.append(python_filepath)
 
-from housinginsights.ingestion.DataReader import ManifestReader
-
 
 #configuration
 #See /logs/example-logging.py for usage examples
@@ -253,8 +251,9 @@ def duplicateTable(new_table, new_json, master_json):
 if __name__ == '__main__':
     #
     # Edit these values before running!
-    csv_filename = os.path.abspath("../../../data/raw/apis/20170613/acs5_2015.csv")#"../../../data/sample/project_sample.csv"
-    table_name = "census"
+    csv_filename = os.path.abspath("../../../data/raw/apis/20170728/mar.csv")#"../../../data/sample
+    # /project_sample.csv"
+    table_name = "mar_geocode"
     encoding = "utf-8" #Try utf-8 or latin1. Put the successful value into manifest.csv
     #print('main(): {}, {}, {}'.format())
     # import ipdb; ipdb.set_trace()

--- a/python/scripts/manifest.csv
+++ b/python/scripts/manifest.csv
@@ -1,4 +1,5 @@
 include_flag,destination_table,unique_data_id,update_method,data_date,encoding,local_folder,s3_folder,filepath,notes
+use,mar,mar,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170728/mar.csv,BUILD FIRST - other tables depend on it
 skip,building_permits,building_permits_2013,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2013.csv,
 skip,building_permits,building_permits_2014,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2014.csv,
 skip,building_permits,building_permits_2015,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2015.csv,

--- a/python/scripts/manifest.csv
+++ b/python/scripts/manifest.csv
@@ -3,7 +3,7 @@ skip,building_permits,building_permits_2013,api,2017-02-02,utf-8,../../../data,h
 skip,building_permits,building_permits_2014,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2014.csv,
 skip,building_permits,building_permits_2015,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2015.csv,
 use,building_permits,building_permits_2016,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2016.csv,
-skip,building_permits,building_permits_2017,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2017.csv,This is still incomplete due to broken opendata.dc.gov . Excluding so we can cleanly say our database is 100% 2016 for clarity until opendata.dc.gov gets fixed
+use,building_permits,building_permits_2017,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2017.csv,This is still incomplete due to broken opendata.dc.gov . Excluding so we can cleanly say our database is 100% 2016 for clarity until opendata.dc.gov gets fixed
 needs cleaner,parcel,parcel_Mar2017,manual,2017-03-15,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,raw/preservation_catalog/20170315/Parcel.csv,
 use,project,project,manual,2017-03-15,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,raw/preservation_catalog/20170315/Project.csv,
 use,reac_score,reac_score_Mar2017,manual,2017-03-15,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,raw/preservation_catalog/20170315/Reac_score.csv,

--- a/python/scripts/meta.json
+++ b/python/scripts/meta.json
@@ -4034,5 +4034,435 @@
         "type": "decimal"
       }
     ]
+  },
+  "mar": {
+    "cleaner": "MarCleaner",
+    "fields": [
+      {
+        "display_name": "Unique data ID",
+        "display_text": "Identifies which source file this record came from",
+        "required_in_source": false,
+        "source_name": "unique_data_id",
+        "sql_name": "unique_data_id",
+        "type": "text"
+      },
+      {
+        "display_name": "X-coordinate",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "X",
+        "sql_name": "xcoord",
+        "type": "decimal"
+      },
+      {
+        "display_name": "Y-coordinate",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "Y",
+        "sql_name": "ycoord",
+        "type": "decimal"
+      },
+      {
+        "display_name": "objectid_12",
+        "display_text": "Internal id numbering from mar repository",
+        "required_in_source": true,
+        "source_name": "OBJECTID_12",
+        "sql_name": "objectid_12",
+        "type": "text"
+      },
+      {
+        "display_name": "site_address_pk",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SITE_ADDRESS_PK",
+        "sql_name": "site_address_pk",
+        "type": "integer"
+      },
+      {
+        "display_name": "MAR ID",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ADDRESS_ID",
+        "sql_name": "mar_id",
+        "type": "text"
+      },
+      {
+        "display_name": "Status",
+        "display_text": "The current status of the address",
+        "required_in_source": true,
+        "source_name": "STATUS",
+        "sql_name": "status",
+        "type": "text"
+      },
+      {
+        "display_name": "ssl",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SSL",
+        "sql_name": "ssl",
+        "type": "text"
+      },
+      {
+        "display_name": "type_",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "TYPE_",
+        "sql_name": "type_",
+        "type": "text"
+      },
+      {
+        "display_name": "entrancetype",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ENTRANCETYPE",
+        "sql_name": "entrancetype",
+        "type": "text"
+      },
+      {
+        "display_name": "Address Number",
+        "display_text": "Address location house number",
+        "required_in_source": true,
+        "source_name": "ADDRNUM",
+        "sql_name": "address_number",
+        "type": "decimal"
+      },
+      {
+        "display_name": "Address number suffix",
+        "display_text": "Address location house number suffix",
+        "required_in_source": true,
+        "source_name": "ADDRNUMSUFFIX",
+        "sql_name": "address_number_suffix",
+        "type": "text"
+      },
+      {
+        "display_name": "Street name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "STNAME",
+        "sql_name": "street_name",
+        "type": "text"
+      },
+      {
+        "display_name": "Street type",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "STREET_TYPE",
+        "sql_name": "street_type",
+        "type": "text"
+      },
+      {
+        "display_name": "Quadrant",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "QUADRANT",
+        "sql_name": "quadrant",
+        "type": "text"
+      },
+      {
+        "display_name": "City",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CITY",
+        "sql_name": "city",
+        "type": "text"
+      },
+      {
+        "display_name": "State",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "STATE",
+        "sql_name": "state",
+        "type": "text"
+      },
+      {
+        "display_name": "Full address",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "FULLADDRESS",
+        "sql_name": "full_address",
+        "type": "text"
+      },
+      {
+        "display_name": "Square",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SQUARE",
+        "sql_name": "square",
+        "type": "text"
+      },
+      {
+        "display_name": "Suffix",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SUFFIX",
+        "sql_name": "suffix",
+        "type": "text"
+      },
+      {
+        "display_name": "Lot",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LOT",
+        "sql_name": "lot",
+        "type": "text"
+      },
+      {
+        "display_name": "nationalgrid",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "NATIONALGRID",
+        "sql_name": "nationalgrid",
+        "type": "text"
+      },
+      {
+        "display_name": "Neighborhood",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ASSESSMENT_NBHD",
+        "sql_name": "neighborhood",
+        "type": "text"
+      },
+      {
+        "display_name": "assessment_subnbhd",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ASSESSMENT_SUBNBHD",
+        "sql_name": "assessment_subnbhd",
+        "type": "text"
+      },
+      {
+        "display_name": "cfsa_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CFSA_NAME",
+        "sql_name": "cfsa_name",
+        "type": "text"
+      },
+      {
+        "display_name": "hotspot",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "HOTSPOT",
+        "sql_name": "hotspot",
+        "type": "decimal"
+      },
+      {
+        "display_name": "Neighborhood cluster",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CLUSTER_",
+        "sql_name": "neighborhood_cluster",
+        "type": "text"
+      },
+      {
+        "display_name": "Police district",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "POLDIST",
+        "sql_name": "poldist",
+        "type": "text"
+      },
+      {
+        "display_name": "roc",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ROC",
+        "sql_name": "roc",
+        "type": "text"
+      },
+      {
+        "display_name": "Police Service Area",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PSA",
+        "sql_name": "psa",
+        "type": "text"
+      },
+      {
+        "display_name": "smd",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SMD",
+        "sql_name": "smd",
+        "type": "text"
+      },
+      {
+        "display_name": "Census tract",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CENSUS_TRACT",
+        "sql_name": "census_tract",
+        "type": "text"
+      },
+      {
+        "display_name": "vote_prcnct",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "VOTE_PRCNCT",
+        "sql_name": "vote_prcnct",
+        "type": "text"
+      },
+      {
+        "display_name": "ward",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "WARD",
+        "sql_name": "ward",
+        "type": "text"
+      },
+      {
+        "display_name": "zipcode",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ZIPCODE",
+        "sql_name": "zipcode",
+        "type": "decimal"
+      },
+      {
+        "display_name": "anc",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ANC",
+        "sql_name": "anc",
+        "type": "text"
+      },
+      {
+        "display_name": "newcommselect06",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "NEWCOMMSELECT06",
+        "sql_name": "newcommselect06",
+        "type": "text"
+      },
+      {
+        "display_name": "newcommcandidate",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "NEWCOMMCANDIDATE",
+        "sql_name": "newcommcandidate",
+        "type": "text"
+      },
+      {
+        "display_name": "census_block",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CENSUS_BLOCK",
+        "sql_name": "census_block",
+        "type": "text"
+      },
+      {
+        "display_name": "census_blockgroup",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CENSUS_BLOCKGROUP",
+        "sql_name": "census_blockgroup",
+        "type": "text"
+      },
+      {
+        "display_name": "focus_improvement_area",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "FOCUS_IMPROVEMENT_AREA",
+        "sql_name": "focus_improvement_area",
+        "type": "decimal"
+      },
+      {
+        "display_name": "se_anno_cad_data",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SE_ANNO_CAD_DATA",
+        "sql_name": "se_anno_cad_data",
+        "type": "decimal"
+      },
+      {
+        "display_name": "latitude",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LATITUDE",
+        "sql_name": "latitude",
+        "type": "decimal"
+      },
+      {
+        "display_name": "longitude",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LONGITUDE",
+        "sql_name": "longitude",
+        "type": "decimal"
+      },
+      {
+        "display_name": "active_res_unit_count",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ACTIVE_RES_UNIT_COUNT",
+        "sql_name": "active_res_unit_count",
+        "type": "decimal"
+      },
+      {
+        "display_name": "res_type",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "RES_TYPE",
+        "sql_name": "res_type",
+        "type": "text"
+      },
+      {
+        "display_name": "active_res_occupancy_count",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ACTIVE_RES_OCCUPANCY_COUNT",
+        "sql_name": "active_res_occupancy_count",
+        "type": "decimal"
+      },
+      {
+        "display_name": "ward_2002",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "WARD_2002",
+        "sql_name": "ward_2002",
+        "type": "text"
+      },
+      {
+        "display_name": "ward_2012",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "WARD_2012",
+        "sql_name": "ward_2012",
+        "type": "text"
+      },
+      {
+        "display_name": "anc_2002",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ANC_2002",
+        "sql_name": "anc_2002",
+        "type": "text"
+      },
+      {
+        "display_name": "anc_2012",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ANC_2012",
+        "sql_name": "anc_2012",
+        "type": "text"
+      },
+      {
+        "display_name": "smd_2002",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SMD_2002",
+        "sql_name": "smd_2002",
+        "type": "text"
+      },
+      {
+        "display_name": "smd_2012",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SMD_2012",
+        "sql_name": "smd_2012",
+        "type": "text"
+      }
+    ],
+    "replace_table": true
   }
 }

--- a/python/scripts/meta.json
+++ b/python/scripts/meta.json
@@ -611,7 +611,7 @@
         "display_text": "",
         "required_in_source": true,
         "source_name": "MARADDRESSREPOSITORYID",
-        "sql_name": "maraddressrepositoryid",
+        "sql_name": "mar_id",
         "type": "text"
       },
       {
@@ -628,6 +628,14 @@
         "required_in_source": true,
         "source_name": "DCSTATLOCATIONKEY",
         "sql_name": "dcstatlocationkey",
+        "type": "text"
+      },
+      {
+        "display_name": "Census Tract",
+        "display_text": "",
+        "required_in_source": false,
+        "source_name": "census_tract",
+        "sql_name": "census_tract",
         "type": "text"
       },
       {

--- a/python/scripts/meta.json
+++ b/python/scripts/meta.json
@@ -4103,19 +4103,19 @@
         "type": "text"
       },
       {
-        "display_name": "type_",
+        "display_name": "Address type",
         "display_text": "",
         "required_in_source": true,
         "source_name": "TYPE_",
-        "sql_name": "type_",
+        "sql_name": "address_type",
         "type": "text"
       },
       {
-        "display_name": "entrancetype",
+        "display_name": "Entrance type",
         "display_text": "",
         "required_in_source": true,
         "source_name": "ENTRANCETYPE",
-        "sql_name": "entrancetype",
+        "sql_name": "entrance_type",
         "type": "text"
       },
       {
@@ -4211,7 +4211,7 @@
         "display_text": "",
         "required_in_source": true,
         "source_name": "NATIONALGRID",
-        "sql_name": "nationalgrid",
+        "sql_name": "national_grid",
         "type": "text"
       },
       {
@@ -4295,11 +4295,11 @@
         "type": "text"
       },
       {
-        "display_name": "vote_prcnct",
+        "display_name": "Voting precinct",
         "display_text": "",
         "required_in_source": true,
         "source_name": "VOTE_PRCNCT",
-        "sql_name": "vote_prcnct",
+        "sql_name": "vote_precinct",
         "type": "text"
       },
       {
@@ -4343,7 +4343,7 @@
         "type": "text"
       },
       {
-        "display_name": "census_block",
+        "display_name": "Census block",
         "display_text": "",
         "required_in_source": true,
         "source_name": "CENSUS_BLOCK",
@@ -4351,11 +4351,11 @@
         "type": "text"
       },
       {
-        "display_name": "census_blockgroup",
+        "display_name": "Census block group",
         "display_text": "",
         "required_in_source": true,
         "source_name": "CENSUS_BLOCKGROUP",
-        "sql_name": "census_blockgroup",
+        "sql_name": "census_block_group",
         "type": "text"
       },
       {
@@ -4399,7 +4399,7 @@
         "type": "decimal"
       },
       {
-        "display_name": "res_type",
+        "display_name": "Residential type",
         "display_text": "",
         "required_in_source": true,
         "source_name": "RES_TYPE",

--- a/python/tests/test_Cleaner.py
+++ b/python/tests/test_Cleaner.py
@@ -1,0 +1,56 @@
+import unittest
+import os
+from python.housinginsights.ingestion.Cleaners import ProjectCleaner, PYTHON_PATH
+from python.housinginsights.ingestion.Manifest import Manifest
+from python.housinginsights.ingestion.functions import load_meta_data
+
+
+class CleanerTestCase(unittest.TestCase):
+    def setUp(self):
+        # use test data
+        test_data_path = os.path.abspath(os.path.join(PYTHON_PATH, 'tests',
+                                                      'test_data'))
+        self.meta_path = os.path.abspath(os.path.join(test_data_path,
+                                                      'meta_load_data.json'))
+        self.manifest_path = os.path.abspath(
+            os.path.join(test_data_path, 'manifest_load_data.csv'))
+        self.database_choice = 'docker_database'
+        self.manifest = Manifest(path=self.manifest_path)
+
+    def test_add_geocode_from_mar(self):
+        # get rows for test cases
+        dchousing_manifest_row = self.manifest.get_manifest_row(
+            unique_data_id='dchousing_project')
+        building_permits_2017_manifest_row = self.manifest.get_manifest_row(
+            unique_data_id='building_permits_2017')
+
+        # mar_id test cases - except for ward other fields are typically Null
+        mar_ids = [148655, 289735, 311058, 308201]
+        fields = ['Ward2012', 'Cluster_tr2000', 'Cluster_tr2000_name',
+                  'Proj_Zip', 'Anc2012', 'Geo2010',
+                  'Status', 'Proj_addre', 'Proj_image_url',
+                  'Proj_streetview_url', 'Psa2012', 'Proj_City', 'Proj_ST']
+        rows = list()
+
+        # populate fields for each case as 'Null'
+        for ids in mar_ids:
+            id_dict = dict()
+            id_dict.setdefault('mar_id', ids)
+            for field in fields:
+                if field == 'Proj_streetview_url':
+                    id_dict[field] = "dummy"
+                else:
+                    id_dict[field] = 'Null'
+            rows.append(id_dict)
+
+        # verify add_geocode_from_mar()
+        cleaner = ProjectCleaner(load_meta_data(self.meta_path),
+                                 dchousing_manifest_row)
+        for row in rows:
+            result = cleaner.add_geocode_from_mar(row)
+            for field in fields:
+                self.assertFalse(result[field] == 'Null', "no 'Nulls' left.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/test_Cleaner.py
+++ b/python/tests/test_Cleaner.py
@@ -21,8 +21,6 @@ class CleanerTestCase(unittest.TestCase):
         # get rows for test cases
         dchousing_manifest_row = self.manifest.get_manifest_row(
             unique_data_id='dchousing_project')
-        building_permits_2017_manifest_row = self.manifest.get_manifest_row(
-            unique_data_id='building_permits_2017')
 
         # mar_id test cases - except for ward other fields are typically Null
         mar_ids = [148655, 289735, 311058, 308201]

--- a/python/tests/test_data/manifest_load_data.csv
+++ b/python/tests/test_data/manifest_load_data.csv
@@ -3,8 +3,8 @@ ____________note all items marked skip in this manifest are ready but are being 
 skip,building_permits,building_permits_2013,api,06/07/2017,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170607/building_permits_2013.csv,
 skip,building_permits,building_permits_2014,api,06/07/2017,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170607/building_permits_2014.csv,
 skip,building_permits,building_permits_2015,api,06/07/2017,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170607/building_permits_2015.csv,
-skip,building_permits,building_permits_2016,api,06/07/2017,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170607/building_permits_2016.csv,
-skip,building_permits,building_permits_2017,api,06/07/2017,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170607/building_permits_2017.csv,This is still incomplete due to broken opendata.dc.gov . Excluding so we can cleanly say our database is 100% 2016 for clarity until opendata.dc.gov gets fixed
+use,building_permits,building_permits_2016,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2016.csv,
+use,building_permits,building_permits_2017,api,2017-02-02,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170606/building_permits_2017.csv,This is still incomplete due to broken opendata.dc.gov . Excluding so we can cleanly say our database is 100% 2016 for clarity until opendata.dc.gov gets fixed
 use,project,project,manual,03/15/2017,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,raw/preservation_catalog/20170315/Project.csv,
 use,subsidy,subsidy_Mar2017,manual,03/15/2017,latin-1,../../../data,https://s3.amazonaws.com/housinginsights/,raw/preservation_catalog/20170315/Subsidy.csv,
 use,project,dchousing_project,api,06/07/2017,utf-8,../../../data,https://s3.amazonaws.com/housinginsights/,raw/apis/20170607/dchousing_project.csv,append to 20170315/project.csv

--- a/python/tests/test_data/meta_load_data.json
+++ b/python/tests/test_data/meta_load_data.json
@@ -1364,5 +1364,435 @@
         "type": "decimal"
       }
     ]
+  },
+  "mar": {
+    "cleaner": "mar",
+    "fields": [
+      {
+        "display_name": "Unique data ID",
+        "display_text": "Identifies which source file this record came from",
+        "required_in_source": false,
+        "source_name": "unique_data_id",
+        "sql_name": "unique_data_id",
+        "type": "text"
+      },
+      {
+        "display_name": "x",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "X",
+        "sql_name": "x",
+        "type": "decimal"
+      },
+      {
+        "display_name": "y",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "Y",
+        "sql_name": "y",
+        "type": "decimal"
+      },
+      {
+        "display_name": "objectid_12",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "OBJECTID_12",
+        "sql_name": "objectid_12",
+        "type": "text"
+      },
+      {
+        "display_name": "site_address_pk",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SITE_ADDRESS_PK",
+        "sql_name": "site_address_pk",
+        "type": "integer"
+      },
+      {
+        "display_name": "address_id",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ADDRESS_ID",
+        "sql_name": "address_id",
+        "type": "text"
+      },
+      {
+        "display_name": "status",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "STATUS",
+        "sql_name": "status",
+        "type": "text"
+      },
+      {
+        "display_name": "ssl",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SSL",
+        "sql_name": "ssl",
+        "type": "text"
+      },
+      {
+        "display_name": "type_",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "TYPE_",
+        "sql_name": "type_",
+        "type": "text"
+      },
+      {
+        "display_name": "entrancetype",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ENTRANCETYPE",
+        "sql_name": "entrancetype",
+        "type": "text"
+      },
+      {
+        "display_name": "addrnum",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ADDRNUM",
+        "sql_name": "addrnum",
+        "type": "decimal"
+      },
+      {
+        "display_name": "addrnumsuffix",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ADDRNUMSUFFIX",
+        "sql_name": "addrnumsuffix",
+        "type": "text"
+      },
+      {
+        "display_name": "stname",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "STNAME",
+        "sql_name": "stname",
+        "type": "text"
+      },
+      {
+        "display_name": "street_type",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "STREET_TYPE",
+        "sql_name": "street_type",
+        "type": "text"
+      },
+      {
+        "display_name": "quadrant",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "QUADRANT",
+        "sql_name": "quadrant",
+        "type": "text"
+      },
+      {
+        "display_name": "city",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CITY",
+        "sql_name": "city",
+        "type": "text"
+      },
+      {
+        "display_name": "state",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "STATE",
+        "sql_name": "state",
+        "type": "text"
+      },
+      {
+        "display_name": "fulladdress",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "FULLADDRESS",
+        "sql_name": "fulladdress",
+        "type": "text"
+      },
+      {
+        "display_name": "square",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SQUARE",
+        "sql_name": "square",
+        "type": "text"
+      },
+      {
+        "display_name": "suffix",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SUFFIX",
+        "sql_name": "suffix",
+        "type": "text"
+      },
+      {
+        "display_name": "lot",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LOT",
+        "sql_name": "lot",
+        "type": "text"
+      },
+      {
+        "display_name": "nationalgrid",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "NATIONALGRID",
+        "sql_name": "nationalgrid",
+        "type": "text"
+      },
+      {
+        "display_name": "assessment_nbhd",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ASSESSMENT_NBHD",
+        "sql_name": "assessment_nbhd",
+        "type": "text"
+      },
+      {
+        "display_name": "assessment_subnbhd",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ASSESSMENT_SUBNBHD",
+        "sql_name": "assessment_subnbhd",
+        "type": "text"
+      },
+      {
+        "display_name": "cfsa_name",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CFSA_NAME",
+        "sql_name": "cfsa_name",
+        "type": "text"
+      },
+      {
+        "display_name": "hotspot",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "HOTSPOT",
+        "sql_name": "hotspot",
+        "type": "decimal"
+      },
+      {
+        "display_name": "cluster_",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CLUSTER_",
+        "sql_name": "cluster_",
+        "type": "text"
+      },
+      {
+        "display_name": "poldist",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "POLDIST",
+        "sql_name": "poldist",
+        "type": "text"
+      },
+      {
+        "display_name": "roc",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ROC",
+        "sql_name": "roc",
+        "type": "text"
+      },
+      {
+        "display_name": "psa",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "PSA",
+        "sql_name": "psa",
+        "type": "text"
+      },
+      {
+        "display_name": "smd",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SMD",
+        "sql_name": "smd",
+        "type": "text"
+      },
+      {
+        "display_name": "census_tract",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CENSUS_TRACT",
+        "sql_name": "census_tract",
+        "type": "decimal"
+      },
+      {
+        "display_name": "vote_prcnct",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "VOTE_PRCNCT",
+        "sql_name": "vote_prcnct",
+        "type": "text"
+      },
+      {
+        "display_name": "ward",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "WARD",
+        "sql_name": "ward",
+        "type": "text"
+      },
+      {
+        "display_name": "zipcode",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ZIPCODE",
+        "sql_name": "zipcode",
+        "type": "decimal"
+      },
+      {
+        "display_name": "anc",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ANC",
+        "sql_name": "anc",
+        "type": "text"
+      },
+      {
+        "display_name": "newcommselect06",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "NEWCOMMSELECT06",
+        "sql_name": "newcommselect06",
+        "type": "text"
+      },
+      {
+        "display_name": "newcommcandidate",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "NEWCOMMCANDIDATE",
+        "sql_name": "newcommcandidate",
+        "type": "text"
+      },
+      {
+        "display_name": "census_block",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CENSUS_BLOCK",
+        "sql_name": "census_block",
+        "type": "text"
+      },
+      {
+        "display_name": "census_blockgroup",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "CENSUS_BLOCKGROUP",
+        "sql_name": "census_blockgroup",
+        "type": "text"
+      },
+      {
+        "display_name": "focus_improvement_area",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "FOCUS_IMPROVEMENT_AREA",
+        "sql_name": "focus_improvement_area",
+        "type": "decimal"
+      },
+      {
+        "display_name": "se_anno_cad_data",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SE_ANNO_CAD_DATA",
+        "sql_name": "se_anno_cad_data",
+        "type": "decimal"
+      },
+      {
+        "display_name": "latitude",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LATITUDE",
+        "sql_name": "latitude",
+        "type": "decimal"
+      },
+      {
+        "display_name": "longitude",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "LONGITUDE",
+        "sql_name": "longitude",
+        "type": "decimal"
+      },
+      {
+        "display_name": "active_res_unit_count",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ACTIVE_RES_UNIT_COUNT",
+        "sql_name": "active_res_unit_count",
+        "type": "decimal"
+      },
+      {
+        "display_name": "res_type",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "RES_TYPE",
+        "sql_name": "res_type",
+        "type": "text"
+      },
+      {
+        "display_name": "active_res_occupancy_count",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ACTIVE_RES_OCCUPANCY_COUNT",
+        "sql_name": "active_res_occupancy_count",
+        "type": "decimal"
+      },
+      {
+        "display_name": "ward_2002",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "WARD_2002",
+        "sql_name": "ward_2002",
+        "type": "text"
+      },
+      {
+        "display_name": "ward_2012",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "WARD_2012",
+        "sql_name": "ward_2012",
+        "type": "text"
+      },
+      {
+        "display_name": "anc_2002",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ANC_2002",
+        "sql_name": "anc_2002",
+        "type": "text"
+      },
+      {
+        "display_name": "anc_2012",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "ANC_2012",
+        "sql_name": "anc_2012",
+        "type": "text"
+      },
+      {
+        "display_name": "smd_2002",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SMD_2002",
+        "sql_name": "smd_2002",
+        "type": "text"
+      },
+      {
+        "display_name": "smd_2012",
+        "display_text": "",
+        "required_in_source": true,
+        "source_name": "SMD_2012",
+        "sql_name": "smd_2012",
+        "type": "text"
+      }
+    ],
+    "replace_table": true
   }
 }

--- a/python/tests/test_data/meta_load_data.json
+++ b/python/tests/test_data/meta_load_data.json
@@ -3,7 +3,7 @@
     "cleaner": "BuildingPermitsCleaner",
     "fields": [
       {
-        "display_name": "x",
+        "display_name": "X",
         "display_text": "Longitude field should be used instead",
         "required_in_source": true,
         "source_name": "X",
@@ -11,7 +11,7 @@
         "type": "decimal"
       },
       {
-        "display_name": "y",
+        "display_name": "Y",
         "display_text": "Latitude field should be used instead",
         "required_in_source": true,
         "source_name": "Y",
@@ -19,7 +19,7 @@
         "type": "decimal"
       },
       {
-        "display_name": "objectid",
+        "display_name": "Object ID",
         "display_text": "",
         "required_in_source": true,
         "source_name": "OBJECTID",
@@ -27,7 +27,7 @@
         "type": "text"
       },
       {
-        "display_name": "dcrainternalnumber",
+        "display_name": "DCRA Internal Number",
         "display_text": "",
         "required_in_source": true,
         "source_name": "DCRAINTERNALNUMBER",
@@ -35,7 +35,7 @@
         "type": "text"
       },
       {
-        "display_name": "issue_date",
+        "display_name": "Issue Date",
         "display_text": "",
         "required_in_source": true,
         "source_name": "ISSUE_DATE",
@@ -43,7 +43,7 @@
         "type": "timestamp"
       },
       {
-        "display_name": "permit_id",
+        "display_name": "Permit ID",
         "display_text": "",
         "required_in_source": true,
         "source_name": "PERMIT_ID",
@@ -51,7 +51,7 @@
         "type": "text"
       },
       {
-        "display_name": "permit_type_name",
+        "display_name": "Permit Type Name",
         "display_text": "",
         "required_in_source": true,
         "source_name": "PERMIT_TYPE_NAME",
@@ -59,7 +59,7 @@
         "type": "text"
       },
       {
-        "display_name": "permit_subtype_name",
+        "display_name": "Permit Subtype Name",
         "display_text": "",
         "required_in_source": true,
         "source_name": "PERMIT_SUBTYPE_NAME",
@@ -67,7 +67,7 @@
         "type": "text"
       },
       {
-        "display_name": "permit_category_name",
+        "display_name": "Permit Category Name",
         "display_text": "",
         "required_in_source": true,
         "source_name": "PERMIT_CATEGORY_NAME",
@@ -75,7 +75,7 @@
         "type": "text"
       },
       {
-        "display_name": "application_status_name",
+        "display_name": "Application Status Name",
         "display_text": "",
         "required_in_source": true,
         "source_name": "APPLICATION_STATUS_NAME",
@@ -83,7 +83,7 @@
         "type": "text"
       },
       {
-        "display_name": "full_address",
+        "display_name": "Full Address",
         "display_text": "",
         "required_in_source": true,
         "source_name": "FULL_ADDRESS",
@@ -91,7 +91,7 @@
         "type": "text"
       },
       {
-        "display_name": "desc_of_work",
+        "display_name": "Description of Work",
         "display_text": "",
         "required_in_source": true,
         "source_name": "DESC_OF_WORK",
@@ -99,7 +99,7 @@
         "type": "text"
       },
       {
-        "display_name": "ssl",
+        "display_name": "SSL",
         "display_text": "",
         "required_in_source": true,
         "source_name": "SSL",
@@ -107,7 +107,7 @@
         "type": "text"
       },
       {
-        "display_name": "zoning",
+        "display_name": "Zoning",
         "display_text": "",
         "required_in_source": true,
         "source_name": "ZONING",
@@ -115,7 +115,7 @@
         "type": "text"
       },
       {
-        "display_name": "permit_applicant",
+        "display_name": "Permit Applicant",
         "display_text": "",
         "required_in_source": true,
         "source_name": "PERMIT_APPLICANT",
@@ -123,7 +123,7 @@
         "type": "text"
       },
       {
-        "display_name": "fee_type",
+        "display_name": "Fee Type",
         "display_text": "",
         "required_in_source": true,
         "source_name": "FEE_TYPE",
@@ -131,7 +131,7 @@
         "type": "text"
       },
       {
-        "display_name": "fees_paid",
+        "display_name": "Fees Paid",
         "display_text": "",
         "required_in_source": true,
         "source_name": "FEES_PAID",
@@ -139,7 +139,7 @@
         "type": "decimal"
       },
       {
-        "display_name": "owner_name",
+        "display_name": "Owner Name",
         "display_text": "",
         "required_in_source": true,
         "source_name": "OWNER_NAME",
@@ -155,7 +155,7 @@
         "type": "timestamp"
       },
       {
-        "display_name": "city",
+        "display_name": "City",
         "display_text": "",
         "required_in_source": true,
         "source_name": "CITY",
@@ -163,7 +163,7 @@
         "type": "text"
       },
       {
-        "display_name": "state",
+        "display_name": "State",
         "display_text": "",
         "required_in_source": true,
         "source_name": "STATE",
@@ -171,7 +171,7 @@
         "type": "text"
       },
       {
-        "display_name": "latitude",
+        "display_name": "Latitude",
         "display_text": "",
         "required_in_source": true,
         "source_name": "LATITUDE",
@@ -179,7 +179,7 @@
         "type": "decimal"
       },
       {
-        "display_name": "longitude",
+        "display_name": "Longitude",
         "display_text": "",
         "required_in_source": true,
         "source_name": "LONGITUDE",
@@ -187,7 +187,7 @@
         "type": "decimal"
       },
       {
-        "display_name": "xcoord",
+        "display_name": "Xcoord",
         "display_text": "",
         "required_in_source": true,
         "source_name": "XCOORD",
@@ -195,7 +195,7 @@
         "type": "decimal"
       },
       {
-        "display_name": "ycoord",
+        "display_name": "Ycoord",
         "display_text": "",
         "required_in_source": true,
         "source_name": "YCOORD",
@@ -203,23 +203,23 @@
         "type": "decimal"
       },
       {
-        "display_name": "zipcode",
+        "display_name": "Zip code",
         "display_text": "",
         "required_in_source": true,
         "source_name": "ZIPCODE",
-        "sql_name": "zipcode",
+        "sql_name": "zip",
         "type": "text"
       },
       {
-        "display_name": "maraddressrepositoryid",
+        "display_name": "Mar Address Repository ID",
         "display_text": "",
         "required_in_source": true,
         "source_name": "MARADDRESSREPOSITORYID",
-        "sql_name": "maraddressrepositoryid",
+        "sql_name": "mar_id",
         "type": "text"
       },
       {
-        "display_name": "dcstataddresskey",
+        "display_name": "DC Stat Address Key",
         "display_text": "",
         "required_in_source": true,
         "source_name": "DCSTATADDRESSKEY",
@@ -227,7 +227,7 @@
         "type": "text"
       },
       {
-        "display_name": "dcstatlocationkey",
+        "display_name": "DC Stat Location Key",
         "display_text": "",
         "required_in_source": true,
         "source_name": "DCSTATLOCATIONKEY",
@@ -235,7 +235,15 @@
         "type": "text"
       },
       {
-        "display_name": "ward",
+        "display_name": "Census Tract",
+        "display_text": "",
+        "required_in_source": false,
+        "source_name": "census_tract",
+        "sql_name": "census_tract",
+        "type": "text"
+      },
+      {
+        "display_name": "Ward",
         "display_text": "",
         "required_in_source": true,
         "source_name": "WARD",
@@ -251,7 +259,7 @@
         "type": "text"
       },
       {
-        "display_name": "smd",
+        "display_name": "SMD",
         "display_text": "",
         "required_in_source": true,
         "source_name": "SMD",
@@ -259,7 +267,7 @@
         "type": "text"
       },
       {
-        "display_name": "district",
+        "display_name": "District",
         "display_text": "",
         "required_in_source": true,
         "source_name": "DISTRICT",
@@ -267,7 +275,7 @@
         "type": "text"
       },
       {
-        "display_name": "psa",
+        "display_name": "PSA",
         "display_text": "",
         "required_in_source": true,
         "source_name": "PSA",
@@ -275,7 +283,7 @@
         "type": "text"
       },
       {
-        "display_name": "neighborhoodcluster",
+        "display_name": "Neighborhood Cluster",
         "display_text": "",
         "required_in_source": true,
         "source_name": "NEIGHBORHOODCLUSTER",
@@ -283,7 +291,7 @@
         "type": "text"
       },
       {
-        "display_name": "hotspot2006name",
+        "display_name": "Hot Spot 2006 Name",
         "display_text": "",
         "required_in_source": true,
         "source_name": "HOTSPOT2006NAME",
@@ -291,7 +299,7 @@
         "type": "text"
       },
       {
-        "display_name": "hotspot2005name",
+        "display_name": "Hot Spot 2005 Name",
         "display_text": "",
         "required_in_source": true,
         "source_name": "HOTSPOT2005NAME",
@@ -299,7 +307,7 @@
         "type": "text"
       },
       {
-        "display_name": "hotspot2004name",
+        "display_name": "Hot Spot 2004 Name",
         "display_text": "",
         "required_in_source": true,
         "source_name": "HOTSPOT2004NAME",
@@ -307,7 +315,7 @@
         "type": "text"
       },
       {
-        "display_name": "businessimprovementdistrict",
+        "display_name": "Business Improvement District",
         "display_text": "",
         "required_in_source": true,
         "source_name": "BUSINESSIMPROVEMENTDISTRICT",
@@ -315,7 +323,7 @@
         "type": "text"
       },
       {
-        "display_name": "Unique data ID",
+        "display_name": "Unique Data ID",
         "display_text": "Identifies which source file this record came from",
         "required_in_source": false,
         "source_name": "unique_data_id",


### PR DESCRIPTION
## What's new

- Fixed bug causing --update-only to fail in LoadData.py

- Added cleaner step that geocodes the census_tract of building permits.

## Notes
Due to size of building permits data needed to improve processing time. For 2016 data file, there's 47k rows with ~37k unique buildings. It was taking 45+ to process and that's if it didn't time out  - I was able to process without issues during evening hours.

#### Solution
Implemented concurrency since the bottleneck was an IO issue - api calls and we don't care the order in which we write the data rows to the psv file for database upload. 

It is currently using a max of 100 threads to process and clean all the rows for a raw data file. This improved processing time considerably - went from 45+ mins to 5-7 mins (398s last night, 329s early this morning).

## Things To Consider: 

- Using threading did cause one issue - too many api calls at times for the same value (mar_id). Resolved this by adding a while loop that waits a second and then tries again when an Exception is thrown. This works nicely - 1s wait seemed the optimal solution; 0.5s and 0.75s actually took much longer to complete but that could be due to me testing after 8am.

- I think we should move this up into the batch api raw data download process and before cleaning process and database loading. I think this would allows us to continue to get the benefit of improved processing time and yet minimize the timing issue when we manually refresh the database when user is testing something out locally. I know others have been having issues updating locally due to mar api timing out at times.
  - I'm thinking add a procedure that is called for any api data that will need geocode cleaning. It will query and update any mar_id location that isn't currently available. So we will end up with mar_geocode table with complete geocode data for most/all buildings - maybe skip if times out and attempt again when actually loading raw data into database: undecided on this right now. The cleaner will lookup using the table and only make api call if building geocode info is missing.
  - I know it seems we're duplicating the work here but this front loads most of the work associated with mar api calls and only makes calls later if the table is missing information and will update the mar_geocode table accordingly. So with each iteration, less calls will be made until the entire batch process is done again.
  - Also, we're already doing some mar api calls in batch processing already so I should be able to connect this all together for smoother processing in general with less requests make to mar api.

## Testing
Run LoadData.py with `docker --update-only building_permits_2016` if database is already built or rebuild the entire database with just `docker`.  **Note: I recommend attempting after 5pm or running on something smaller, maybe project or dchousing_project.**

## To Do

- Process and load building_permits_2017 data. Note - this raw data is still causing something to error out - investigating further to see if I can figure out what is going on.