### PR TITLE
Jo 442 filter ui bugs

### DIFF
--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -404,6 +404,7 @@ var filterView = {
             );
 
             setState(specific_state_code, [returnVals['min']['min'], returnVals['max']['max'], ths.toggle.element.checked]);
+            ths.checkAgainstOriginalValues(+returnVals['min']['min'], +returnVals['max']['max'], ths.toggle.element.checked)
         }
         this.textBoxes.setInputCallback(inputCallback);
 
@@ -642,6 +643,7 @@ var filterView = {
             );
 
             setState(specific_state_code, [dateValues.min, dateValues.max, ths.toggle.element.checked]);
+            ths.checkAgainstOriginalValues(dateValues.min, dateValues.max, ths.toggle.element.checked);
         }
 
         // For separating date inputs with a '/'

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -484,7 +484,18 @@ var filterView = {
                 unencoded.push(ths.nullsShown);
 
                 if(doesItSetState){
+                    console.log('min',minDatum);
+                    console.log('max',maxDatum);
+                    console.log(this);
+                    console.log(unencoded);
                     setState(specific_state_code,unencoded);
+                    if ( unencoded[0] === minDatum && unencoded[1] === maxDatum && unencoded[2] === true ){
+                        console.log('back to original');
+                        var filterControl = filterView.filterControls.find(function(each){
+                            return each.component.short_name === c.short_name;
+                        });
+                        filterControl.clear();
+                    }                    
                 }
 
             }

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -389,6 +389,8 @@ var filterView = {
             var textboxValues = ths.textBoxes.returnValues();
             var newState = [textboxValues['min']['min'], textboxValues['max']['max'],checkboxValue]
             setState(specificCode, newState);
+            ths.checkAgainstOriginalValues(+textboxValues['min']['min'], +textboxValues['max']['max'], checkboxValue);
+
         });
 
         //Textbox
@@ -433,20 +435,18 @@ var filterView = {
 
                     var specific_state_code = 'filterValues.' + component.source
                     unencoded.push(ths.toggle.element.checked);
-
                     setState(specific_state_code,unencoded);
-                    if ( unencoded[0] === minDatum && unencoded[1] === maxDatum && unencoded[2] === true ){
-                        console.log('back to original');
-                        var filterControl = filterView.filterControls.find(function(each){
-                            return each.component.short_name === c.short_name;
-                        });
-                        filterControl.clear();
-                    }                    
+                    ths.checkAgainstOriginalValues(min,max,unencoded[2]);
+                                       
                 }
 
             }
         }
-
+        this.checkAgainstOriginalValues = function(min,max,showNulls){
+            if ( min === this.minDatum && max === this.maxDatum && showNulls === true ){
+                ths.clear();
+            } 
+        }
         // Changing value should trigger map update
         var currentSliderCallback = makeSliderCallback(c, true)
         this.slider.noUiSlider.on('change', currentSliderCallback);

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -602,6 +602,7 @@ var filterView = {
                 if(doesItSetState){
                     ths.toggle.element.checked
                     setState(specific_state_code,[newMinDate, newMaxDate, ths.toggle.element.checked]);
+                    ths.checkAgainstOriginalValues(newMinDate, newMaxDate, ths.toggle.element.checked)
                 }
             }
         }
@@ -667,6 +668,7 @@ var filterView = {
             var dateValues = getValuesAsDates();
             var newState = [dateValues.min, dateValues.max,checkboxValue]
             setState(specificCode, newState);
+            ths.checkAgainstOriginalValues(dateValues.min, dateValues.max, checkboxValue)
         });
 
         this.clear = function(){
@@ -682,6 +684,14 @@ var filterView = {
         this.isTouched = function(){
             var dateValues = getValuesAsDates();
             return dateValues.min !== minDatum || dateValues.max !== maxDatum || this.nullsShown === false;
+        }
+
+        this.checkAgainstOriginalValues = function(min,max,showNulls){
+            console.log(min.getTime(),max.getTime(),showNulls);console.log(minDatum.getTime(),maxDatum.getTime());            
+            if ( min.getTime() === minDatum.getTime() && max.getTime() === maxDatum.getTime() && showNulls === true ){
+                console.log('match');
+                ths.clear();
+            } 
         }
 
     },


### PR DESCRIPTION
Addresses first bug listed in issue #442 .

Pillboxes and URL encoding clear when date and continuous filters are set back to their original settings. Works on sliders, checkbox, and text inputs.