### PR TITLE
396 Make very small changes to the categorical dropdown menus

### DIFF
--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -65,6 +65,12 @@ html, body {
     font-weight: bold;
 }
 
+/* Ensure there's no extra scroll bar within
+the container for categorical filters */
+div.filter.categorical.content.active {
+    overflow: visible;
+}
+
 /* Text input boxes within sidebars */
 div.filter.content input.filter-text{
     display: inline-block;

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -807,13 +807,13 @@ var filterView = {
         var c = this.component;
 
         var contentContainer = filterView.setupFilter(c);
-
+        
         var uiSelector = contentContainer.append("select")
             .classed("ui fluid search dropdown",true)
             .classed("dropdown-" + c.source,true)    //need to put a selector-specific class on the UI to run the 'get value' statement properly
             .attr("multiple", " ")
             .attr("id", c.source);
-
+    
         //Add the dropdown menu choices
         for(var j = 0; j < c.options.length; j++){
             uiSelector.append("option").attr("value", c.options[j]).text(c.options[j])
@@ -830,6 +830,11 @@ var filterView = {
             setState(specific_state_code,selectedValues);
         }};
         var currentSelectCallback = makeSelectCallback(c)
+
+        // Add the search box placeholder text
+        var searchBox = contentContainer.select('input')
+            .attr('placeholder', "Type here to search.")
+            .style('width', '100%');
         
         //TODO change this to a click event instead of any change
         $(".dropdown-"+c.source).change(currentSelectCallback);


### PR DESCRIPTION
Addresses #396 

1. Adds placeholder text to the input boxes within the Semantic UI dropdown menus for the categorical filters. 

2. Explicitly specifies the 'overflow' CSS of the container for categorical filter components. This may not be necessary, given the 'visible' is the default value for 'overflow' anyway, but I wanted to ensure that the container wouldn't be rendered with an overflow of 'scroll'.