### PR TITLE
Remove table during update

### DIFF
--- a/python/housinginsights/ingestion/SQLWriter.py
+++ b/python/housinginsights/ingestion/SQLWriter.py
@@ -154,7 +154,8 @@ class HISql(object):
         # TODO make sure data is synced or appended properly
         sql_manifest_row = self.get_sql_manifest_row(db_conn=conn,
                                                      close_conn=False)
-        if sql_manifest_row is None:
+
+        if sql_manifest_row is not None:
             logging.info("  deleting existing manifest row for {}".format(
                 self.unique_data_id))
             delete_command = \
@@ -272,6 +273,7 @@ class HISql(object):
             return results[0]
 
         if len(results) == 0:
+            logging.info("  Couldn't find sql_manifest_row for {}".format(self.unique_data_id))
             return None
 
     def get_sql_fields_and_type_from_meta(self, table_name=None):

--- a/python/scripts/load_data.py
+++ b/python/scripts/load_data.py
@@ -41,6 +41,10 @@ parser.add_argument('-s', '--sample', help='load with sample data',
 parser.add_argument('--update-only', nargs='+',
                     help='only update tables with these unique_data_id '
                          'values')
+parser.add_argument('--remove-tables', nargs='+',
+                    help='Drops tables before running the load data code. '
+                    ' Add the name of each table to drop in format "table1 table2"')
+
 parser.add_argument('--manual', help='Ignore all other arguments and use'
                     'what is hard coded here, for debugging/testing purposes',
                     action='store_true')
@@ -73,4 +77,5 @@ if arguments.manual:
 #typically we use the approach that is coded into LoadData.py
 else:
     # Let the main method handle it
+    print(arguments)
     main(arguments)


### PR DESCRIPTION
Provides 2 ways for a table to be dropped (along w/ associated sql manifest rows) when updating the database. This allows for the addition/removal of columns while updating a single table, instead of only being able to do so by rebuilding the whole database. 

Also includes a few try/except blocks for the zone_facts table. Add logging.error when a field could not be found/calculated due to missing data - this means the rebuilding of the database will still work even if a necessary table (building_permits, census, etc. ) is missing. Allows for faster testing of things that only apply to certain sections of the database b/c you can add 'skips' to any tables you're not currently working on. 