### PR TITLE
333 Fix ContinuousFilterControl.isTouched() and dateFilterControl.isTouched()

### DIFF
--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -477,7 +477,7 @@ var filterView = {
 
         this.isTouched = function(){
             var returnVals = ths.textBoxes.returnValues();
-            return returnVals.min.min !== this.minDatum || returnVals.max.max !== this.maxDatum || this.nullsShown === false;
+            return returnVals.min.min != this.minDatum || returnVals.max.max != this.maxDatum || this.nullsShown === false;
         };
 
         this.set = function(min,max,nullValue){
@@ -693,7 +693,7 @@ var filterView = {
 
         this.isTouched = function(){
             var dateValues = getValuesAsDates();
-            return dateValues.min !== minDatum || dateValues.max !== maxDatum || this.nullsShown === false;
+            return dateValues.min.valueOf() !== minDatum.valueOf() || dateValues.max.valueOf() !== maxDatum.valueOf() || this.nullsShown === false;
         }
 
         this.checkAgainstOriginalValues = function(min,max,showNulls){


### PR DESCRIPTION
Addresses #333 

The former had tried to match the string return value of the text inputs with the numeric return value of min/maxDatum.

The latter had tried to use an equivalence operator on JS Date objects, which can't be done. I've used the operator on the valueOf() those Dates instead.

Now only 'touched' filter controls should clear.