### PR TITLE
Dedupe project and DHCD datasets

### DIFF
--- a/python/housinginsights/ingestion/SQLWriter.py
+++ b/python/housinginsights/ingestion/SQLWriter.py
@@ -154,7 +154,8 @@ class HISql(object):
         # TODO make sure data is synced or appended properly
         sql_manifest_row = self.get_sql_manifest_row(db_conn=conn,
                                                      close_conn=False)
-        if sql_manifest_row is None:
+
+        if sql_manifest_row is not None:
             logging.info("  deleting existing manifest row for {}".format(
                 self.unique_data_id))
             delete_command = \
@@ -272,6 +273,7 @@ class HISql(object):
             return results[0]
 
         if len(results) == 0:
+            logging.info("  Couldn't find sql_manifest_row for {}".format(self.unique_data_id))
             return None
 
     def get_sql_fields_and_type_from_meta(self, table_name=None):

--- a/python/housinginsights/sources/DCHousing.py
+++ b/python/housinginsights/sources/DCHousing.py
@@ -38,8 +38,6 @@ class DCHousingApiConn(BaseApiConn):
     def get_data(self, unique_data_ids=None, sample=False, output_type='csv',
                  **kwargs):
         """
-        Returns JSON object of the entire data set.
-
         """
         if unique_data_ids is None:
             unique_data_ids = self._available_unique_data_ids
@@ -68,3 +66,8 @@ class DCHousingApiConn(BaseApiConn):
                         self._available_unique_data_ids[0], PROJECT_FIELDS_MAP,
                         SUBSIDY_FIELDS_MAP, db)
 
+
+if __name__ == '__main__':
+    
+    apiConn = DCHousingApiConn()
+    apiConn.create_project_subsidy_csv()

--- a/python/housinginsights/sources/DCHousing.py
+++ b/python/housinginsights/sources/DCHousing.py
@@ -13,7 +13,7 @@ from housinginsights.sources.models.DCHousing import PROJECT_FIELDS_MAP,\
     SUBSIDY_FIELDS_MAP
 
 
-class DCHousingApiConn(BaseApiConn):
+class DCHousingApiConn(ProjectBaseApiConn):
     """
     API Interface to the Affordable Housing data set on opendata.dc.gov.
 

--- a/python/housinginsights/sources/dhcd.py
+++ b/python/housinginsights/sources/dhcd.py
@@ -25,7 +25,7 @@ from xmljson import parker as xml_to_json
 import json
 
 
-from housinginsights.sources.base import BaseApiConn
+from housinginsights.sources.base import ProjectBaseApiConn
 from housinginsights.sources.models.dhcd import APP_ID, TABLE_ID_MAPPING, \
                                                         APP_METADATA_FIELDS, \
                                                         TABLE_METADATA_FIELDS, \
@@ -36,7 +36,7 @@ from housinginsights.sources.models.dhcd import APP_ID, TABLE_ID_MAPPING, \
 INCLUDE_ALL_FIELDS = True
 
 
-class DhcdApiConn(BaseApiConn):
+class DhcdApiConn(ProjectBaseApiConn):
     """
     API Interface to the DHCD DFD data on projects
     pending funding and development.

--- a/python/housinginsights/sources/dhcd.py
+++ b/python/housinginsights/sources/dhcd.py
@@ -29,7 +29,10 @@ from housinginsights.sources.base import BaseApiConn
 from housinginsights.sources.models.dhcd import APP_ID, TABLE_ID_MAPPING, \
                                                         APP_METADATA_FIELDS, \
                                                         TABLE_METADATA_FIELDS, \
-                                                        DhcdResult
+                                                        DhcdResult, \
+                                                        PROJECT_FIELDS_MAP,\
+                                                        SUBSIDY_FIELDS_MAP
+
 INCLUDE_ALL_FIELDS = True
 
 
@@ -290,6 +293,7 @@ class DhcdApiConn(BaseApiConn):
 
         """
         data_json = None
+        db = kwargs.get('db', None)
 
         if unique_data_ids is None:
             unique_data_ids = self._available_unique_data_ids
@@ -317,9 +321,10 @@ class DhcdApiConn(BaseApiConn):
                     results = [ DhcdResult({e.tag: e.text for e in list(r)}, self._fields[u]).data for r in data_xml_records ]
 
                     self.result_to_csv(self._fields[u], results, self.output_paths[u])
+                    
+                    self.create_project_subsidy_csv('dhcd_dfd_properties', PROJECT_FIELDS_MAP, SUBSIDY_FIELDS_MAP, db)
 
-        # Return last result data set as JSON object
-        return data_json
+
 
 
 # For testing purposes (running this as a script):

--- a/python/housinginsights/sources/models/dhcd.py
+++ b/python/housinginsights/sources/models/dhcd.py
@@ -71,6 +71,77 @@ TABLE_METADATA_FIELDS = [
 ]
 
 
+SUBSIDY_FIELDS_MAP = {'Nlihc_id': None, 
+                        'Subsidy_id': None,
+                        'Units_Assist': 'units__total_number_of_affordable_units',
+                        'POA_start': None, 
+                        'POA_end': None,
+                        'contract_number': None, 
+                        'rent_to_fmr_description': None,
+                        'Subsidy_Active': None, 
+                        'Subsidy_Info_Source_ID': None,
+                        'Subsidy_Info_Source': None,
+                        'Subsidy_Info_Source_Date': None, 
+                        'Update_Dtm': None,
+                        'Program': None, 
+                        'Compl_end': None, 
+                        'POA_end_prev': None,
+                        'Agency': None, 
+                        'POA_start_orig': None, 
+                        'Portfolio': None,
+                        'Subsidy_info_source_property': None,
+                        'POA_end_actual': None
+                      }
+
+PROJECT_FIELDS_MAP = {  'Nlihc_id': None,
+                        'Status': None, 
+                        'Subsidized': None,
+                        'Cat_Expiring': None,
+                        'Cat_Failing_Insp': None,
+                        'Proj_Name': 'property_name', 
+                        'Proj_City': None,
+                        'Proj_ST': None, 
+                        'Proj_Zip': None, 
+                        'Proj_Units_Tot': None,
+                        'Proj_Units_Assist_Min': "units__total_number_of_affordable_units",
+                        'Proj_Units_Assist_Max': "units__total_number_of_affordable_units",
+                        'Hud_Own_Effect_dt': None, 
+                        'Hud_Own_Name': None,
+                        'Hud_Own_Type': None, 
+                        'Hud_Mgr_Name': None,
+                        'Hud_Mgr_Type': None, 
+                        'Subsidy_Start_First': None,
+                        'Subsidy_Start_Last': None, 
+                        'Subsidy_End_First': None,
+                        'Subsidy_End_Last': None, 
+                        'Ward2012': None,
+                        'PBCA': None, 
+                        'Anc2012': None, 
+                        'Psa2012': None,
+                        'Geo2010': None, 
+                        'Cluster_tr2000': None,
+                        'Cluster_tr2000_name': None, 
+                        'Zip': None,
+                        'Proj_image_url': None, 
+                        'Proj_streetview_url': None,
+                        'Proj_address_id': 'mar_id', #calculated during create_project_subsidy_csv
+                        'Proj_x': None,
+                        'Proj_y': None, 
+                        'Proj_lat': None,
+                        'Proj_lon': None,
+                        'Update_Dtm': None, #date_modified but wrong format
+                        'Subsidy_info_source_property': None,
+                        'contract_number': None, 
+                        'Proj_addre': 'address_single', #calculated during create_project_subsidy_csv
+                        'Bldg_count': None, 
+                        'Category_Code': None,
+                        'Cat_At_Risk': None, 
+                        'Cat_More_Info': None,
+                        'Cat_Lost': None, 
+                        'Cat_Replaced': None
+                        }
+
+
 class DhcdResult(object):
 
     def __init__(self, result, fields):

--- a/python/housinginsights/tools/misc.py
+++ b/python/housinginsights/tools/misc.py
@@ -1,0 +1,66 @@
+
+
+from housinginsights.sources.mar import MarApiConn
+import logging
+
+def check_mar_for_address(addr, conn):
+        '''
+        Looks for a matching address in the MAR
+        Currently just uses a 
+        '''
+
+        #Used to perform common string replacements in addresses. 
+        #The key is original, value is what we want it to become
+        #values match format typically found in the mar table
+        #Allows first-pass matching of address strings to the MAR
+            # (failed matches are then bumped up to more robust methods)
+        address_string_mapping = {
+            "Northeast":"NE",
+            "Northwest":"NW",
+            "Southeast":"SE",
+            "Southwest":"SW",
+            "St ":"Street ",
+            "St. ":"Street ",
+            "Pl ":"Place ",
+            "Pl. ":"Place ",
+            "Ave ":"Avenue ",
+            "Ave. ":"Avenue "
+        }
+
+        # Format addr by matching the conventions of the MAR
+        for key, value in address_string_mapping.items():
+            addr = addr.replace(key,value)
+
+        ###########################
+        # Attempt #1 - direct match
+        ###########################
+        query = """
+                select mar_id from mar
+                where full_address ='{}'
+                """.format(addr.upper()) #MAR uses upper case in the full_address field
+
+        query_result = conn.execute(query)
+
+        result = [dict(x) for x in query_result.fetchall()]
+
+        if result:
+            return result[0]['mar_id']
+
+        ###########################
+        # Attempt #2 - MAR API
+        ###########################
+        logging.info("  checking mar API")
+        mar_api = MarApiConn()
+        result = mar_api.find_location(location=addr)
+        if (result['returnDataset'] == None or 
+            result['returnDataset'] == {} or
+            result['sourceOperation'] == 'DC Intersection'):
+
+            #Means we didn't find a proper match
+            result = None
+
+        if result:
+            return result['returnDataset']['Table1'][0]['ADDRESS_ID']
+
+        #If no match found:
+        return None

--- a/python/scripts/get_api_data.py
+++ b/python/scripts/get_api_data.py
@@ -113,7 +113,8 @@ if __name__ == '__main__':
                             #  'acs5_2013','acs5_2014','acs5_2015',
                             #  'acs5_2009_moe','acs5_2010_moe','acs5_2011_moe','acs5_2012_moe',
                             #  'acs5_2013_moe','acs5_2014_moe','acs5_2015_moe',
-                            #  'wmata_stops','wmata_dist'
+                            #  'wmata_stops','wmata_dist',
+                            #  'mar'
                             # ]
     sample = False          # Some ApiConn classes can just grab a sample of the data for dev/testing
     output_type = 'csv'     # Other option is 'stdout' which just prints to console

--- a/python/scripts/load_data.py
+++ b/python/scripts/load_data.py
@@ -41,6 +41,10 @@ parser.add_argument('-s', '--sample', help='load with sample data',
 parser.add_argument('--update-only', nargs='+',
                     help='only update tables with these unique_data_id '
                          'values')
+parser.add_argument('--remove-tables', nargs='+',
+                    help='Drops tables before running the load data code. '
+                    ' Add the name of each table to drop in format "table1 table2"')
+
 parser.add_argument('--manual', help='Ignore all other arguments and use'
                     'what is hard coded here, for debugging/testing purposes',
                     action='store_true')
@@ -73,4 +77,5 @@ if arguments.manual:
 #typically we use the approach that is coded into LoadData.py
 else:
     # Let the main method handle it
+    print(arguments)
     main(arguments)


### PR DESCRIPTION
This is a first pass at implementing the matching of records in the DHCD dataset to those that already exist in the project table. It uses the same method as the DCHousing dataset to create project and subsidy tables out of a single "project" table. Currently just using simple string matching against the `mar` table of the database to geocode the rows of the DHCD data set. 

Still to do:
- Implement better geocoding w/ calls to the MAR api 
- Deal with dirty address data - multiple addresses in one line, sometimes written out sometimes just the street numbers
- Use the 'dhcd projects' table (equivalent to our subsidies table) to better describe subsidies. Currently this file is coming in blank from the API requests. 
- Map more fields

Note, this PR also includes the changes in #462 

## To test
- Add the mar data set to your database:
    - edit get_api_data.py to use `unique_data_ids = ['mar']`
    - from /python/scripts run `python get_api_data.py` to download a local copy of the mar data, which should update your manifest.csv
    - run `python load_data.py --update-only mar` to add the mar to your database

- Get the DHCD data
    - edit get_api_data.py to use `unique_data_ids = None` and `module_list = ['dhcd']`
    - run `python get_api_data.py`