### PR TITLE
472 search for project

### DIFF
--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -710,3 +710,22 @@ dl.inline dt{
   display: inline-block;
   min-width: 75px;
 }
+
+
+/*search bar*/
+#searchbar .dropdown {
+    border-radius:15px;
+    max-width:400px;
+    float:right;
+    margin-right:10px;
+    margin-left:50px;
+}
+
+#searchbar {
+    height:30px;
+}
+
+/*patches semantic ui bug that search helper text is cut off after clearing a pillbox*/
+input.search {
+    width:200px !important;
+}

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -89,7 +89,8 @@ var router = {
             }
             if ( dataChoice.component_type === 'categorical' || dataChoice.component_type === 'searchbar' ){
                 var values = eachArray[1].replace(/_/g,' ').split('+');
-                $('.ui.dropdown.'+'dropdown-' + dataChoice.source).dropdown('set selected', values);
+                var dropdown_element = $('.ui.dropdown.'+'dropdown-' + dataChoice.source)
+                    dropdown_element.dropdown('set selected', values);
             }   
             if ( dataChoice.component_type === 'date' ){
                 // handle decoding for date type filter here

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -46,7 +46,7 @@ var router = {
                 var separator = router.stateObj[key] && router.stateObj[key][2] ? '-' : '_';
                 paramsArray.push(dataChoice.short_name + '=' + Math.round(router.stateObj[key][0]) + separator + Math.round(router.stateObj[key][1])); 
             }
-            if ( dataChoice.component_type === 'categorical' ){
+            if ( dataChoice.component_type === 'categorical' || dataChoice.component_type === 'searchbar' ){
                 paramsArray.push( dataChoice.short_name + '=' + router.stateObj[key].join('+'));
             }
             if ( dataChoice.component_type === 'date' ){
@@ -87,7 +87,7 @@ var router = {
                 filterControlObj.set(min,max,nullsShown);
                 
             }
-            if ( dataChoice.component_type === 'categorical' ){
+            if ( dataChoice.component_type === 'categorical' || dataChoice.component_type === 'searchbar' ){
                 var values = eachArray[1].replace(/_/g,' ').split('+');
                 $('.ui.dropdown.'+'dropdown-' + dataChoice.source).dropdown('set selected', values);
             }   

--- a/docs/tool/js/util/filter.js
+++ b/docs/tool/js/util/filter.js
@@ -114,7 +114,7 @@ var filterUtil = {
                 }
 			}
 
-			if (component['component_type'] == 'categorical') {
+			if (component['component_type'] == 'categorical' || component['component_type'] == 'searchbar') {
 				workingData = workingData.filter(function(d){
                     //If all objects are removed from filter list, assume they want all objects
                     if (filterValues[key][0].length == 0 ) {

--- a/docs/tool/js/views/dataChoices.js
+++ b/docs/tool/js/views/dataChoices.js
@@ -12,15 +12,43 @@
         //""source"" is the column name from the filter table, which should match the table in the original database table.
         //  For this approach to work, it will be cleanest if we never have duplicate column names in our sql tables unless the data has
         //  the same meaning in both places (e.g. "ward" and "ward" can appear in two tables but should have same name/format)
+        
+        //TOODO this source should be converted to 'proj_name_addre' when it is available from the api
+        {   "source":"proj_name",
+            "display_name": "Search",
+            "display_text": "This is the searchbar",
+            "component_type": "searchbar",
+            "data_type": "text",
+            "data_level": "project",
+            "short_name": "na"
+        },
+        
         {   "source":"location",
-            "display_name": "Location",
+            "display_name": "Specific Zone",
             "display_text": "View only projects in a specific zone of the city. The choices in this filter depend on the Zone Type selected, and the filter is cleared when the Zone Type is changed.",
             "component_type": "location",
             "data_type": "text",
             "data_level": "project",
             "short_name": "l"
         },
-
+        /* TODO enable this once proj_name_addre is available above (don't want two of same filter controls)
+        {   "source":"proj_name",
+            "display_name": "Project name",
+            "display_text": "Filter to a specific building by searching for its name",
+            "component_type": "categorical",
+            "data_type": "text",
+            "data_level": "project",
+            "short_name": "n"
+        },
+        */
+        {   "source":"proj_addre",
+            "display_name": "Project address",
+            "display_text": "Filter to a specific building by searching for its address",
+            "component_type": "categorical",
+            "data_type": "text",
+            "data_level": "project",
+            "short_name": "a"
+        },
         {   "source": "proj_units_tot",
             "display_name": "Total units in project",
             "display_text": "Total count of units in the project, including both subsidized and market rate units.",

--- a/docs/tool/js/views/dataChoices.js
+++ b/docs/tool/js/views/dataChoices.js
@@ -14,7 +14,7 @@
         //  the same meaning in both places (e.g. "ward" and "ward" can appear in two tables but should have same name/format)
         
         //TOODO this source should be converted to 'proj_name_addre' when it is available from the api
-        {   "source":"proj_name",
+        {   "source":"proj_name", //change to proj_name_addre
             "display_name": "Search",
             "display_text": "This is the searchbar",
             "component_type": "searchbar",

--- a/docs/tool/js/views/dataChoices.js
+++ b/docs/tool/js/views/dataChoices.js
@@ -12,9 +12,8 @@
         //""source"" is the column name from the filter table, which should match the table in the original database table.
         //  For this approach to work, it will be cleanest if we never have duplicate column names in our sql tables unless the data has
         //  the same meaning in both places (e.g. "ward" and "ward" can appear in two tables but should have same name/format)
-        
-        //TOODO this source should be converted to 'proj_name_addre' when it is available from the api
-        {   "source":"proj_name", //change to proj_name_addre
+
+        {   "source":"proj_name_addre",
             "display_name": "Search",
             "display_text": "This is the searchbar",
             "component_type": "searchbar",
@@ -31,7 +30,6 @@
             "data_level": "project",
             "short_name": "l"
         },
-        /* TODO enable this once proj_name_addre is available above (don't want two of same filter controls)
         {   "source":"proj_name",
             "display_name": "Project name",
             "display_text": "Filter to a specific building by searching for its name",
@@ -40,7 +38,6 @@
             "data_level": "project",
             "short_name": "n"
         },
-        */
         {   "source":"proj_addre",
             "display_name": "Project address",
             "display_text": "Filter to a specific building by searching for its address",

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -851,6 +851,63 @@ var filterView = {
 
     },
 
+     searchFilterControl: function(component){
+        //Creates the search bar used with the name_addre field
+        //Note, this is currently only configured to be used for one searchbar with the div id=searchbar
+        //TODO fair amount of copy-modified code between this and the categorical one, would be good to consolidate
+        filterView.filterControl.call(this, component);
+        var c = this.component;
+        var contentContainer = d3.select('#searchbar')
+                        .append('div')
+                        .attr('id','filter-content-'+c.source);
+
+        var uiSelector = contentContainer.append("select")
+            .classed("ui fluid multiple search selection dropdown",true)
+            .classed("dropdown-" + c.source,true)    //need to put a selector-specific class on the UI to run the 'get value' statement properly
+            .attr("multiple", " ")
+            .attr("id", c.source + '-searchbar');
+        
+        //Add the dropdown menu choices
+        for(var j = 0; j < c.options.length; j++){
+            uiSelector.append("option").attr("value", c.options[j]).text(c.options[j])
+        }
+
+        //Allow mid-string searches
+        $('#'+c.source + '-searchbar').dropdown({ 
+                fullTextSearch: 'exact'
+                });
+
+        //Change the icon
+        d3.select('#searchbar').select('.icon')
+            .classed('dropdown',false)
+            .classed('search',true)
+
+        //Set callback for when user makes a change
+        function makeSelectCallback(component){
+            return function(){
+            var selectedValues = $('.ui.dropdown.'+'dropdown-'+component.source).dropdown('get value');
+            var specific_state_code = 'filterValues.' + component.source
+            setState(specific_state_code,selectedValues);
+        }};
+        var currentSelectCallback = makeSelectCallback(c)
+
+        // Add the search box placeholder text
+        d3.select('#searchbar').select('input')
+            .attr('placeholder', "Search for a project...")
+            .style('width', '100%');
+        
+        //TODO change this to a click event instead of any change
+        $(".dropdown-"+c.source).change(currentSelectCallback);
+
+        this.clear = function(){
+            $('.dropdown-' + c.source).dropdown('restore defaults');
+        }
+        
+        this.isTouched = function(){
+           return $('.dropdown-' + c.source).dropdown('get value').length > 0;
+        }
+
+    },
 
     locationFilterControl: function(component){
         filterView.categoricalFilterControl.call(this, component);
@@ -908,11 +965,6 @@ var filterView = {
             if (filterView.components[i].component_type === 'date'){
                 new filterView.dateFilterControl(filterView.components[i]);
             }
-                           
-            var parent = d3.select('#filter-components')
-                  .classed("ui styled fluid accordion", true)   //semantic-ui styling
-            $('#filter-components').accordion({'exclusive':true}) //allows multiple opened
-
             
             //set up categorical pickers
             if (filterView.components[i].component_type == 'categorical'){
@@ -929,6 +981,22 @@ var filterView = {
                 new filterView.categoricalFilterControl(filterView.components[i]);
                   
             };
+
+            //search by name and address
+            if (filterView.components[i].component_type == 'searchbar'){
+
+                //First find the unique list of categories
+                var result = [];
+                for (var dataRow = 0; dataRow < workingData.length; dataRow++) {
+                    if(!result.includes(workingData[dataRow][filterView.components[i].source])){
+                        result.push(workingData[dataRow][filterView.components[i].source]);
+                    }
+                };
+                filterView.components[i]['options'] = result;
+
+                new filterView.searchFilterControl(filterView.components[i]);
+
+            }
 
             //set up location picker
             if (filterView.components[i].component_type == 'location'){

--- a/docs/tool/partials/map-view.html
+++ b/docs/tool/partials/map-view.html
@@ -8,6 +8,9 @@
             <button class="sub-nav-button" id="button-filters">Data Choices</button>
         </div>
         <div id="options-spacer">
+            <div id="searchbar">
+            <!--<i class="search icon"></i>-->
+            </div>
         </div>
         <div id="right-options">
             <button class="sub-nav-button" id="button-charts">Summary</button>

--- a/python/.elasticbeanstalk/config.yml
+++ b/python/.elasticbeanstalk/config.yml
@@ -11,7 +11,7 @@ global:
   instance_profile: null
   platform_name: null
   platform_version: null
-  profile: housinginsights_api  #Tells which credentials to use; needs to be set up in your awscli config
+  profile: codefordc  #Tells which credentials to use; needs to be set up in your awscli config
   repository: null
   sc: null
   workspace_type: Application

--- a/python/api/filter_blueprint.py
+++ b/python/api/filter_blueprint.py
@@ -22,6 +22,7 @@ def construct_filter_blueprint(name, engine):
                 p.nlihc_id
                 , p.proj_addre
                 , p.proj_name
+                , CONCAT(p.proj_name, ': ', p.proj_addre) as proj_name_addre
                 , p.proj_units_tot
                 , p.proj_units_assist_max
                 , cast(p.proj_units_assist_max / p.proj_units_tot as decimal(3,2)) as percent_affordable_housing --TODO make this calculated field in projects table

--- a/python/api/project_extended_constructor.py
+++ b/python/api/project_extended_constructor.py
@@ -19,7 +19,8 @@ def construct_project_extended_blueprint(name, engine):
         
         q = """
             select
-            p.*
+            p.*,
+            CONCAT(p.proj_name, ': ', p.proj_addre) as proj_name_addre
             """
         q += ward_selects
         q += cluster_selects


### PR DESCRIPTION
Adds a searchbar to the top navigation, and adds two filter categories of project name and project address to the left sidebar. The searchbar uses a combined name/address field called 'proj_name_addre' which has been added to the API for the /filter and /projects endpoints. This has already been deployed to the live API so that this functionality can be tested w/out spinning up a local api server and swapping urls. 

The search bar is a re-styled combo search/dropdown box, the same one we use for categorical data choices, and behaves like a regular filter control - this seemed like the fastest way to get a basic search functionality integrated into our current workflow. One downside is that it doesn't produce true 'search results' like a user might expect, rather it provides instant filtered results in the dropdown menu. 

Currently this simply applies the filter the way a regular filter works, i.e. highlighting the project on the map. However, we could attach another event to the searchbar selection that takes them to the project view associated with the one matching project. Not sure which behaviour users would find more intuitive. At a minimum, we could activate the 'matching projects' tab, since the 'summary' tab does not make much sense when only one building is selected. 

Should be ready to merge. Note the encoding/decoding on the url is working, though there seems to be a bug in all url decoding that causes it to fail to color code the dots sometimes. 