### PR TITLE
Adds nested JSON data for one-to-many tables in project endpoint

### DIFF
--- a/python/api/project_extended_constructor.py
+++ b/python/api/project_extended_constructor.py
@@ -2,7 +2,9 @@ from flask import Blueprint
 from api.utils import get_zone_facts_select_columns
 from flask import jsonify
 
-def construct_project_extended_blueprint(name, engine):
+from sqlalchemy.sql import text
+
+def construct_project_extended_blueprint(name, engine, tables, models):
     '''
     Provides an endpoint that provides an extended version of the project table that has been joined to 
     other tables. In particular, it joins to the zone_facts table to provide de-normalized statistics 
@@ -32,11 +34,31 @@ def construct_project_extended_blueprint(name, engine):
             left join zone_facts as z3 on z3.zone = p.census_tract
             """
         if nlihc_id != None:
-            q+= "WHERE nlihc_id = '{}'".format(nlihc_id)
+            q+= "WHERE nlihc_id =:nlihc_id"#.format(nlihc_id)
 
         conn = engine.connect()
-        proxy = conn.execute(q)
+        proxy = conn.execute(text(q), nlihc_id=nlihc_id)
+
         results = [dict(x) for x in proxy.fetchall()]
+        
+
+        #Add one-to-many table results
+        if nlihc_id != None and len(results) > 0:
+            for tablename in ['topa', 'subsidy','real_property','reac_score']:
+                if tablename in tables:
+                    try:
+                        q = """
+                            select t.*
+                            from {} as t
+                            where nlihc_id=:nlihc_id;
+                            """.format(tablename) #using if tablename in tables above to protect against sql injection
+
+                        proxy = conn.execute(text(q),tablename=tablename, nlihc_id=nlihc_id)
+                        res = [dict(x) for x in proxy.fetchall()]
+                        results[0][tablename] = res
+                    except Exception as e:
+                        results[0][tablename] = 'Error'
+
         conn.close()
         output = {'objects': results}
         return jsonify(output)

--- a/python/application.py
+++ b/python/application.py
@@ -189,7 +189,7 @@ sum_obs_blue = construct_summarize_observations('sum_obs',engine)
 project_view_blue = construct_project_view_blueprint('project_view',engine)
 filter_blue = construct_filter_blueprint('filter', engine)
 zone_facts = construct_zone_facts_blueprint('zone_facts',engine)
-project_extended = construct_project_extended_blueprint('project_extended',engine)
+project_extended = construct_project_extended_blueprint('project_extended',engine, tables, models)
 
 # Register all the blueprints
 for blueprint in [sum_obs_blue, project_view_blue, filter_blue, zone_facts, project_extended]:


### PR DESCRIPTION
hat currently have an nlihc_id. Currently this means that the `topa`, `subsidy`, `real_property` and `reac_score` tables are now available on the project endpoint whenver you request the data for a specific nlihc_id. For performance reasons the data from these tables are not added to the json when a list of all projects is requested.

- Adds sql-injection protection to this endpoint

To test:
- Spin up server with `python application.py`
- visit localhost:5000/api/projects/NL000196

Deployed to live server