### PR TITLE
WIP: Jo ui suggestions

### DIFF
--- a/docs/tool/css/filters.css
+++ b/docs/tool/css/filters.css
@@ -12,7 +12,9 @@
 
 #filter-components {
   padding-bottom: 150px;
-  
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
 }
 
 .filter-group {

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -199,11 +199,16 @@ button.nullValuesToggleSubmit::before {
     display: block;
     left: 100%;
     height: 40px;
+    width: 200px;
 
 }
 
 #clear-pillbox-holder:hover {
     height: initial;
+}
+
+#clear-pillbox-holder .ui.label {
+    min-height: 30px;   
 }
 
 .ui.label.clear-single {
@@ -586,6 +591,11 @@ a.active {
     font-weight: bold;
     border-top: 1px solid rgba(34, 36, 38, 0.15);
 }
+
+#filters {
+    overflow-y: hidden;
+}
+
 /*Mimics accordion content styling*/
 #filters .static-content {
     margin: 0;

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -203,7 +203,7 @@ button.nullValuesToggleSubmit::before {
 
 }
 
-#clear-pillbox-holder:hover {
+#clear-pillbox-holder:hover, #clear-pillbox-holder.force-hover {
     height: initial;
 }
 
@@ -228,7 +228,11 @@ button.nullValuesToggleSubmit::before {
  
 }
 
-#clear-pillbox-holder:hover .clear-single.visible {
+.ui.label.clear-single.visible:last-child {
+    margin-bottom: 100px;
+}
+
+#clear-pillbox-holder:hover .clear-single.visible, #clear-pillbox-holder.force-hover .clear-single.visible {
     padding: 0.833em;
     max-height: 72px;
     position: relative;

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -195,8 +195,9 @@ button.nullValuesToggleSubmit::before {
 }
 
 #clear-pillbox-holder {
-    position: relative;
+    position: absolute;
     display: block;
+    left: 100%;
 }
 .main-view {
     width: 100%;
@@ -481,6 +482,11 @@ Others are working correctly.
     bottom: 0;
 }
 
+
+#layer-menu-buttons button {
+        border: 5px solid #fff;
+    padding: 9px 3px;
+}
 
 /*
 Switched to semantic-ui buttons instead

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -198,7 +198,39 @@ button.nullValuesToggleSubmit::before {
     position: absolute;
     display: block;
     left: 100%;
+    height: 40px;
+
 }
+
+#clear-pillbox-holder:hover {
+    height: initial;
+}
+
+.ui.label.clear-single {
+    transition: padding-top 0.2s linear, padding-bottom 0.2s linear, max-height 0.2s linear, background .1s ease;
+    overflow: hidden;
+}
+.ui.label.clear-single.visible {
+    padding-top: 0;
+    padding-bottom: 0;
+    max-height: 0;
+    position: absolute;
+    left: 0;
+    top: 0;
+    opacity: 0;
+    margin-top: 0;
+
+ 
+}
+
+#clear-pillbox-holder:hover .clear-single.visible {
+    padding: 0.833em;
+    max-height: 72px;
+    position: relative;
+    top: initial;
+    opacity: 1;
+}
+
 .main-view {
     width: 100%;
     transition: opacity 0.5s linear, transform 0.5s ease-in;
@@ -652,8 +684,7 @@ a.active {
     display: block !important;
     position: relative;
     font-size: .95em;
-    margin-top:5px;
-    margin-left: 2px;
+    margin:5px 2px;
     cursor: pointer;
 }
 

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -688,6 +688,13 @@ a.active {
     cursor: pointer;
 }
 
+.ui.label.label-all {
+    background-color: rgba(253,126,35,0.7) !important;
+        display: inline !important;
+         font-size: .95em;
+    margin:5px 2px;
+}
+
 .ui.label.clear-all:hover {
     color: rgb(50, 50, 50) !important;
 }

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -42,7 +42,7 @@ html, body {
 .sub-nav-container {
     position: relative;
     display: none;
-    overflow-y: auto;
+    
 }
 
 .sub-nav-container.active {

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -1082,7 +1082,7 @@ var filterView = {
     },
     clearAllButton: {
         init: function(){
-            var thisButton = this;
+
 
             this.pill = document.createElement('div');
             this.pill.id = 'clearFiltersPillbox';
@@ -1096,10 +1096,26 @@ var filterView = {
             this.pill.addEventListener('click', function(){
                 filterView.clearAllFilters();
             });
+            this.appendLabelPill()
+        },
+        appendLabelPill: function() {
+            this.labelPill = document.createElement('div');
+            
+            this.labelPill.classList.add('label-all','ui','label');
+
+            this.site = document.getElementById('clear-pillbox-holder');
+
+            this.site.insertBefore(this.labelPill, this.site.firstChild);
+            this.labelPill.textContent = 'Filtered';
         },
         site: undefined,
         tearDown: function(){
-            d3.select('#'+this.pill.id)
+            d3.select('.clear-all')
+                .transition()
+                    .duration(750)
+                    .style("opacity",0)
+                    .remove();
+            d3.select('.label-all')
                 .transition()
                     .duration(750)
                     .style("opacity",0)
@@ -1125,7 +1141,7 @@ var filterView = {
                 activeFilterControls.push(control)
             };
         }
-
+        setState('numberOfFilters', activeFilterControls.length);
         var nullsShown = filterUtil.getNullsShown();
         Object.keys(nullsShown).forEach(function(key){
             var control = filterView.filterControls.find(function(obj){
@@ -1201,7 +1217,6 @@ var filterView = {
             .append('i')
             .classed("delete icon",true)
             .on("click", function(d) {
-              //  d3.event.stopPropagation();
                 d.clear();
             })
                  

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -1157,8 +1157,15 @@ var filterView = {
         });
         
         //Use d3 to bind the list of control objects to our html pillboxes
-        var allPills = d3.select('#clear-pillbox-holder')
-                        .selectAll('.clear-single')
+        var holder = d3.select('#clear-pillbox-holder')
+                        .classed('force-hover', true);
+
+        setTimeout(function(){
+            holder.classed('force-hover', false);
+        }, 2000);
+
+
+        var allPills = holder.selectAll('.clear-single')
                         .data(activeFilterControls, function(d){
                             return d.component.source;
                         })

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -952,19 +952,17 @@ var filterView = {
                   .classed("ui styled fluid accordion", true)   //semantic-ui styling
 
         $('#filter-components').accordion({'exclusive':true, 'onOpen':function(){
-            var difference = $( this ).offset().top + $( this ).height() - $('#filters').offset().top - $('#filters').height(); 
-            /* for debug:
-            console.log($( this ).offset().top + $( this ).height());
+            var difference = $( this ).offset().top - $('#filter-components').offset().top; 
+            
+            console.log($( this ).offset().top);
             console.log('vs');
-            console.log($('#filters').offset().top + $('#filters').height() );
+            console.log($('#filter-components').offset().top);
             console.log(difference);
-            */
-            if ( $( this ).offset().top + $( this ).height() > $('#filters').offset().top + $('#filters').height() ) { 
+            
               // if the accordion content extend below the bounds of the #filters container
-                $('#filters').animate({
-                    scrollTop: $( '#filters' ).scrollTop() + difference + 30
-                }, 500)
-            }
+            $('#filter-components').animate({
+                scrollTop: $( '#filter-components' ).scrollTop() + difference - 29
+            }, 500)
         }});
 
         //Add components to the navigation using the appropriate component type
@@ -1191,11 +1189,11 @@ var filterView = {
                 if ( !$accordion.hasClass('active') ){
                     $accordion.click();
                 } else {
-                    var $filterContent = $('#filter-content-' + d.component.source);
-                    var difference = $filterContent.offset().top + $filterContent.height() - $('#filters').offset().top - $('#filters').height(); 
-                    $('#filters').animate({
-                        scrollTop: $( '#filters' ).scrollTop() + difference + 30
-                    }, 500);
+                    
+                    var difference = $accordion.offset().top - $('#filter-components').offset().top; 
+                    $('#filter-components').animate({
+                        scrollTop: $( '#filter-components' ).scrollTop() + difference
+                    }, 500)
                 }
             })
 
@@ -1203,7 +1201,7 @@ var filterView = {
             .append('i')
             .classed("delete icon",true)
             .on("click", function(d) {
-                d3.event.stopPropagation();
+              //  d3.event.stopPropagation();
                 d.clear();
             })
                  

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -524,6 +524,9 @@
                 .attr('id', function() {
                     return layer.source + '-menu-item';
                 })
+                .attr('title', function(){
+                    return layer.display_text;
+                })
                 .classed('active', (layer.visibility === 'visible'))
                 .text(function() {
                     return layer.display_name;
@@ -557,9 +560,6 @@
                 .classed('active',false)
             d3.select('#' + data + '-menu-item')
                 .classed('active',true);
-            d3.select('#zone-choice-description')
-                .text(mapView.initialLayers.find(x => x.source === data).display_text)
-
         },
         updateZoneChoiceDisabling: function(msg,data) { // e.g. data = {overlay:'crime',grouping:'neighborhood_cluster',activeLayer:'neighborhood_cluster'}
             //Checks to see if the current overlay is different from previous overlay

--- a/docs/tool/partials/map-view.html
+++ b/docs/tool/partials/map-view.html
@@ -21,6 +21,7 @@
 
     <div id="outer-map-wrapper">
         <div id="sidebar-left" class="sidebar left">
+        <div id="clear-pillbox-holder"></div>
             <button class="sidebar-tab"><div class="triangle right"></div></button>
             <div class="sidebar-inner-wrapper">
 
@@ -41,12 +42,9 @@
                 <div id="filters" class="sub-nav-container">
                     <div id="zone-choice-header" class="header">1) Select Zone Type</div>
                     <div id="layer-menu"></div>
-                    <div class="static-content">
-                        <p id="zone-choice-description">Select a zone type to see a description of that zone.</p>
-                    </div>
                     <div id="data-choice-header" class="header">2) Data choices</div>
                     <div id="filter-components">
-                        <div id="clear-pillbox-holder"></div><!--will be style positioned downwards-->
+                        
                     </div>
                 </div>
 


### PR DESCRIPTION
This PR suggests change the UI display of how filters are scrolled and how the pillboxes appear. For review.

Instead of the entire sidebar scroll, in effect moving the zone-type selectors and the active-filter pillboxes out of view, only the inner container scrolls:

![scroll](https://user-images.githubusercontent.com/13643664/29848686-64fd0fdc-8cf0-11e7-8a3b-58772041ae40.gif)

Zonetype descriptions are title text that appear on hover rather than static, where they took up valuable real estate.

Pillboxes fly to a position over the map but only appear when that area is hovered over. We had similar positions in earlier version and opted against it, but I think other changes made since then make this preferable:

![flyto](https://user-images.githubusercontent.com/13643664/29848798-e86741a8-8cf0-11e7-940b-4f32dee2524c.gif)

Opening filter accordions or clicking on their pillboxes scrolls the filter to the top of the container:

![open](https://user-images.githubusercontent.com/13643664/29848870-45b9c4d4-8cf1-11e7-9015-a60d6bcda1de.gif)




