### PR TITLE
initial draft of handoff doc

### DIFF
--- a/docs/data/handoff-documentation.md
+++ b/docs/data/handoff-documentation.md
@@ -1,0 +1,63 @@
+---
+layout: main
+title: Status of the Project
+---
+
+As of October 2017, version 1.0 of the Housing Insights application has been released to a broad user base, which includes city officials, 
+affordable housing policy experts, and tenant advocates.  Users will be able to submit feedback to the development team from directly within the app,
+and Code for DC will assume responsibility for addressing any feedback received.
+
+In January 2018, an advisory council consisting of select development team members and users will convene to review all user feedback received since launch,
+and to plan future development work as warranted.  Additional meetings of the council on a quarterly basis may also be warranted, depending on the level
+of user engagement with the tool.
+
+<br>
+
+# Roadmap for Future Improvements  
+
+## Adding More Data  
+
+The Housing Insights database includes records from the [Preservation Catalog](http://www.neighborhoodinfodc.org/dcpreservationcatalog/), 
+[DC's Open Data data set of affordable housing properties](http://opendata.dc.gov/datasets/affordable-housing), and the Quickbase Database maintained by the Department of Housing and Community Development (DHCD),
+which makes it the most comprehensive data set of affordable housing in DC.  
+
+That said, the 1.0 version does not yet include all available affordable housing inventory in the city.  Some of the inventory is represented in 
+datasets that are especially difficult to source and process, such as future affordable housing stock mentioned in Planned Unit Development (PUD) 
+applications, which provide insight into new affordable housing in the pipeline.  Adding more data about these and other future development projects 
+will be especially important for understanding whether the supply of affordable housing in the city is sufficient to meet the demand.
+
+<br>
+
+## Improving the User Experience  
+
+Prior to releasing version 1.0, the Housing Insights team conducted approximately 50 interviews with potential users, as well as two rounds of live 
+user testing (featuring 3-4 users per round).  Although the interviews and live tests were critical to guiding the design for the app, additional
+features and enhancements will undoubtedly need to be made as the tool transitions to production use.  
+
+Going forward, it will be important to 
+maintain a catalog of user suggestions, comments and bug reports in order to prioritize future development efforts.  Some potential features that may 
+be worth considering in the future include:
+
+- adding the ability for each user to save/persist multiple custom searches/filters across sessions
+- adding the ability to alert a user when new data is received for specific projects and/or queries of interest to them
+- adding the ability for users to incorporate their own comments/annotations for projects and/or queries of interest to them
+
+<br>
+
+## Enhanced Analytics  
+
+Many of the filters available to users draw on some basic analytics developed by the Housing Insights team (e.g., distance from
+project to nearest metro, "zone facts", etc).  There are many more analytics that could still be developed and integrated into the tool however, 
+especially those related to the three topics of greatest interest to target users:
+
+- Risk of loss
+- Value to community and residents
+- Cost or effort to preserve 
+
+ 
+
+
+
+
+
+


### PR DESCRIPTION
First crack at handoff documentation.  Will need some more work, especially to include adding links back into all the other onboarding docs that will still remain relevant.

This is just a swag, so if this isn't what we need, please hack away at it as necessary.