### PR TITLE
496 - Additional address format parsing

### DIFF
--- a/python/housinginsights/tools/misc.py
+++ b/python/housinginsights/tools/misc.py
@@ -3,6 +3,7 @@
 from housinginsights.sources.mar import MarApiConn
 import logging
 
+
 def quick_address_cleanup(addr):
      #Used to perform common string replacements in addresses. 
         #The key is original, value is what we want it to become
@@ -19,7 +20,11 @@ def quick_address_cleanup(addr):
             " Pl ":" Place ",
             " Pl. ":" Place ",
             " Ave ":" Avenue ",
-            " Ave. ":" Avenue "
+            " Ave. ":" Avenue ",
+            "N.E.": "NE",
+            "N.W.": "NW",
+            "S.E.": "SE",
+            "S.W.": "SW"
         }
 
         # Format addr by matching the conventions of the MAR
@@ -27,6 +32,7 @@ def quick_address_cleanup(addr):
             addr = addr.replace(key,value)
 
         return addr
+
 
 def check_mar_for_address(addr, conn):
         '''
@@ -71,15 +77,19 @@ def check_mar_for_address(addr, conn):
         return None
 
 
+def get_unique_addresses_from_str(address_string=""):
+    """
+    Utility method for parsing an address string into a list of well
+    formatted unique addresses: "<address number> <street name> <quadrant>". The
+    process involves first parsing multiple address delimiters (semicolons and
+    " and ") into a list. Then for each result parsing address number range
+    delimiters to get a list of unique addresses.
 
-def get_unique_addresses_from_str(address_str=""):
+    :param address_string: the address string to be processed
+    :return: a list of unique addresses
+    """
 
-    def _trim_str(add_str):
-        """Helper function that does some simple string cleaning."""
-        add_str = add_str.lstrip()
-        add_str = add_str.rstrip()
-        return add_str
-
+    # Helper functions for multiple address delimiters parsing #
     def _parse_semicolon_delimiter(address_list):
         """Helper function that handles parsing semicolon delimiters"""
         output = list()
@@ -87,7 +97,7 @@ def get_unique_addresses_from_str(address_str=""):
             temp_results = add_str.split(sep=';')
             if len(temp_results) > 1:
                 for address in temp_results:
-                    output.append(_trim_str(address))
+                    output.append(address.strip())
             else:
                 output.append(add_str)
         return output
@@ -99,70 +109,146 @@ def get_unique_addresses_from_str(address_str=""):
             temp_results = add_str.split(sep=' and ')
             if len(temp_results) > 1:
                 for address in temp_results:
-                    output.append(_trim_str(address))
+                    output.append(address.strip())
             else:
                 output.append(add_str)
         return output
 
-    def _parse_ampersand_delimiter(address_list):
-        """Helper function that handles parsing '&' delimiters"""
-        output = list()
-        for add_str in address_list:
-            temp_results = add_str.split(sep='&')
-            if len(temp_results) > 1:
-                num_1 = _trim_str(temp_results[0])
-                base = _trim_str(temp_results[1])
-                num_2, base = base.split(' ', 1)
-                num_2 = _trim_str(num_2)
-                base = _trim_str(base)
+    # Begin parsing process #
+    # used to track resulting addresses from multiple address delimiter parsing
+    multiple_addresses_result = [address_string]
 
-                output.append('{} {}'.format(num_1, base))
-                output.append('{} {}'.format(num_2, base))
+    # 1: first parse multiple address delimiters: ';', 'and'
+    multiple_addresses_result = _parse_semicolon_delimiter(
+        multiple_addresses_result)
+    multiple_addresses_result = _parse_and_delimiter(
+        multiple_addresses_result)
+
+    # 2: second parse address numbers delimiters #
+    unique_addresses_result = list()
+
+    # iterate through results from parsing multiple address delimiters
+    for addr_str in multiple_addresses_result:
+        # handle 'other's special case
+        if addr_str == 'others':
+            unique_addresses_result.append(addr_str)
+            continue
+
+        delimiter_stack = list()  # used to track delimiters within addr_str
+        str_stack = list()  # used to track string literals in addr_str
+
+        # populate delimiter_stack and str_stack accordingly from addr_str
+        _str = ''
+        for char in addr_str:
+            if char in {'-', ',', '&'}:
+                if len(_str) > 0:  # add current str partition into stack
+                    str_stack.append(_str)
+                    _str = ''  # restart str tracking
+                delimiter_stack.append(char)
             else:
-                output.append(add_str)
-        return output
+                _str += char
 
-    def _parse_dash_delimiter(address_list):
-        """Helper function that handles parsing '-' delimiters"""
-        output = list()
-        for add_str in address_list:
-            temp_results = add_str.split(sep='-')
-            if len(temp_results) > 1:
-                num_1 = _trim_str(temp_results[0])
-                base = _trim_str(temp_results[1])
-                num_2, base = base.split(' ', 1)
-                num_2 = _trim_str(num_2)
-                base = _trim_str(base)
+        # validate stacks to handle contiguous range delimiter cases
+        if len(delimiter_stack) > len(str_stack):
+            logging.warning('Invalid address: {}'.format(
+                addr_str))
+            unique_addresses_result.append(addr_str)
+            continue
 
-                #TODO is this properly handling a bad address range situation??
-                if not isinstance(num_1,int) or not isinstance(num_2,int):
-                    #there was some parseing problem - throw it back
-                    output.append(add_str)
+        base_str = _str.strip()  # initialize base to be remaining _str val
+
+        # Determine 'address_num' and '<streetname> <quadrant' base for
+        # generating all unique addresses for addr_str. If it cannot be
+        # partitioned accordingly return addr_str as-is
+        try:
+            addr_num, base = base_str.split(' ', 1)
+            _ = int(addr_num)  # validate address number partition
+            unique_addresses_result.append(base_str)
+        except ValueError:
+            # handle '<streetname>, <quadrant>' address cases
+            delim = delimiter_stack.pop()
+
+            if delim == ',':
+                _str = str_stack.pop().strip()
+
+                # flag '<address_num>, <streetname> <quadrant>' as invalid case
+                try:
+                    _ = int(_str)
+                    logging.warning('Invalid address: {}'.format(
+                        addr_str))
+                    unique_addresses_result.append(addr_str)
                     continue
+                except ValueError:
+                    base_str = '{} {}'.format(_str, base_str)
+                    addr_num, base = base_str.split(' ', 1)
+                    unique_addresses_result.append(base_str)
+
+            else:  # fail cleanly for all other invalid cases
+                logging.warning('Invalid address: {}'.format(
+                    addr_str))
+                unique_addresses_result.append(addr_str)
+                continue
+
+        num = addr_num  # reset prior to parsing new 'addr_str' batch
+
+        while delimiter_stack:
+            # get next delimiter
+            delim = delimiter_stack.pop()
+
+            if delim == ',':
+                num = str_stack.pop().strip()
+                unique_addresses_result.append('{} {}'.format(num, base))
+
+            elif delim == '-':
+                shift_range_by = 0  # exclude original base address number?
+                # handle composites - check num exists and assign accordingly
+                try:
+                    addr_num = num
+                    num = str_stack.pop().strip()
+                except NameError as e:
+                    logging.warning(
+                        'Missing "num" - using default addr_num: {}'.format(e))
+                    num = str_stack.pop().strip()
+
+                # check range style and convert accordingly 1210-12 vs 1210-1212
+                if len(num) > len(addr_num):
+                    diff = len(num) - len(addr_num)
+                    addr_num = num[:diff] + addr_num
+                    # remove added based_str in final_pass_result and shift range by 1
+                    _ = unique_addresses_result.pop()
+                    shift_range_by += 1
 
                 # check whether odd, even, or ambiguous range
-                even = True if int(num_1) % 2 == 0 else False
+                even = True if int(num) % 2 == 0 else False
 
-                if (int(num_2) % 2 == 0 and not even) or (
-                            int(num_2) % 2 != 0 and even):
+                if (int(addr_num) % 2 == 0 and not even) or (
+                                    int(addr_num) % 2 != 0 and even):
                     even = None
 
                 # populate address number ranges
                 step = 1 if even is None else 2
-                for num in range(int(num_1), int(num_2) + 1, step):
-                    output.append('{} {}'.format(num, base))
-            else:
-                output.append(add_str)
-        return output
 
-    result = [address_str]  # tracks unique addresses from address_str
+                for cur_num in range(int(num), int(addr_num) + shift_range_by,
+                                     step):
+                    unique_addresses_result.append('{} {}'.format(cur_num, base))
 
-    # 1: parse complete address delimiters - ';', 'and'
-    result = _parse_semicolon_delimiter(result)
-    result = _parse_and_delimiter(result)
+            elif delim == '&':
+                num = str_stack.pop().strip()
 
-    # 2: parse address number range delimiters  - '&', '-'
-    result = _parse_ampersand_delimiter(result)
-    result = _parse_dash_delimiter(result)
+                if num == '':  # skip if next in str is empty or space
+                    continue
 
-    return result
+                try:
+                    # check if actually number, else return original
+                    _ = int(num)
+                    unique_addresses_result.append('{} {}'.format(num, base))
+                except ValueError:
+                    # remove previous result that was added incorrectly
+                    _ = unique_addresses_result.pop()
+                    logging.warning('Invalid address: {} & {}'.format(
+                        num, base_str))
+                    unique_addresses_result.append('{} & {}'.format(
+                        num, base_str))
+
+    return unique_addresses_result
+

--- a/python/tests/test_tools_misc.py
+++ b/python/tests/test_tools_misc.py
@@ -9,14 +9,19 @@ import housinginsights.tools.misc as misc_tools
 
 
 class ToolsMiscTestCase(unittest.TestCase):
+
     def test_get_unique_addresses_from_str(self):
-        # Cases for complete address delimiters #
+        # Cases for multiple addresses delimiters #
         # case 1: ';' delimiter separated addresses
-        address_str = '1110 Aspen Street NW; 6650 Georgia Avenue NW; 6656 Georgia Avenue NW; others'
+        address_str = '1110 Aspen Street NW; 6650 Georgia Avenue NW; ' \
+                      '6656 Georgia Avenue NW; others'
         expected_result = ['1110 Aspen Street NW', '6650 Georgia Avenue NW',
                            '6656 Georgia Avenue NW', 'others']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed ";" - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed ";" - returned less/more unique '
+                         'addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
                             "Failed ';' delimiter case: {}".format(address))
@@ -25,32 +30,44 @@ class ToolsMiscTestCase(unittest.TestCase):
         address_str = '1110 Aspen Street NW and 6650 Georgia Avenue NW'
         expected_result = ['1110 Aspen Street NW', '6650 Georgia Avenue NW']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed " and " - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed " and " - returned less/more unique '
+                         'addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
-                            "Failed 'and' delimiter case")
+                            'Failed "and" delimiter case: {}'.format(address))
 
         # Cases for address number ranges #
         # case 3: '&' delimiter separated address
         address_str = '1521 & 1523 16th Street NW'
         expected_result = ['1521 16th Street NW', '1523 16th Street NW']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed "&" - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed "&" - returned less/more unique '
+                         'addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
-                            "Failed '&' delimiter case")
+                            'Failed "&" delimiter case: {}'.format(address))
 
-        """Seperating into multiple cases for now but it seems is best to assume +2 when given address number ranges. Examples for real data seems to confirm this.
+        """
+        Separating into multiple cases for now but it seems best to assume 
+        +2 when given address number ranges. Examples for real data seems to 
+        confirm this.
         """
         # case 4a: '-' odd delimiter address number ranges
         address_str = '1309-1313 E Street SE'
         expected_result = ['1309 E Street SE', '1311 E Street SE',
                            '1313 E Street SE']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed odd "-" - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed odd "-" - returned less/more unique '
+                         'addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
-                            "Failed odd '-' delimiter case")
+                            'Failed odd "-" delimiter case: {}'.format(address))
 
         # case 4b: '-' even delimiter address number ranges
         address_str = '4000-4008 8th Street NE'
@@ -58,10 +75,14 @@ class ToolsMiscTestCase(unittest.TestCase):
                            '4004 8th Street NE', '4006 8th Street NE',
                            '4008 8th Street NE']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed even "-" - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed even "-" - returned less/more unique '
+                         'addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
-                            "Failed even '-' delimiter case")
+                            'Failed even "-" delimiter case: {}'.format(
+                                address))
 
         # case 4c: '-' ambiguous delimiter address number ranges
         address_str = '4000-4005 8th Street NE'
@@ -69,10 +90,14 @@ class ToolsMiscTestCase(unittest.TestCase):
                            '4004 8th Street NE', '4001 8th Street NE',
                            '4003 8th Street NE', '4005 8th Street NE']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed ambiguous "-" - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed ambiguous "-" - returned less/more unique '
+                         'addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
-                            "Failed ambiguous '-' delimiter case")
+                            'Failed ambiguous "-" delimiter case: {}'.format(
+                                address))
 
         # Cases for composites #
         # case 5: '&' + 'and' delimiter separated addresses
@@ -80,49 +105,296 @@ class ToolsMiscTestCase(unittest.TestCase):
         expected_result = ['1521 16th Street NW', '1523 16th Street NW',
                            '1531 Church Street NW']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed "&" + " and " - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed "&" + " and " - returned less/more unique '
+                         'addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
-                            "Failed '&' + 'and' delimiter composite")
+                            "Failed '&' + 'and' delimiter "
+                            "composite: {}".format(address))
 
         # case 6: both addresses delimiter and address number ranges
-        address_str = '1110 Aspen Street NW; 4000-4005 8th Street NE; 6650 Georgia Avenue NW; 2420-2428 14th Street NE'
+        address_str = '1110 Aspen Street NW; 4000-4005 8th Street NE; ' \
+                      '6650 Georgia Avenue NW; 2420-2428 14th Street NE'
         expected_result = ['1110 Aspen Street NW', '4000 8th Street NE',
                            '4002 8th Street NE', '4004 8th Street NE',
                            '4001 8th Street NE', '4003 8th Street NE',
                            '4005 8th Street NE', '6650 Georgia Avenue NW',
-                           '2420 14th Street NE',
-                           '2422 14th Street NE',
-                           '2424 14th Street NE',
-                           '2426 14th Street NE',
+                           '2420 14th Street NE', '2422 14th Street NE',
+                           '2424 14th Street NE', '2426 14th Street NE',
                            '2428 14th Street NE']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed both number range and multiple '
+                                'addresses delimiter - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed both number range and multiple addresses '
+                         'delimiter - returned less/more unique '
+                         'addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
-                            "Failed both number range and address delimiter cases")
+                            "Failed both number range and address delimiter"
+                            " cases: {}".format(address))
 
         # case 7: composite of many delimiters
-        address_str = '4232-4238 4th Street SE and 4281-4285 6th Street SE; 1521 & 1523 16th Street NW and 1531 Church Street NW'
+        address_str = '4232-4238 4th Street SE and 4281-4285 6th Street SE; ' \
+                      '1521 & 1523 16th Street NW and 1531 Church Street NW'
         expected_result = ['4232 4th Street SE', '4234 4th Street SE',
                            '4236 4th Street SE', '4238 4th Street SE',
                            '4281 6th Street SE', '4283 6th Street SE',
                            '4285 6th Street SE', '1523 16th Street NW',
                            '1521 16th Street NW', '1531 Church Street NW']
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
+        self.assertTrue(result, 'Failed composite of many delimiter - returned '
+                                'empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed composite of many delimiter - returned '
+                         'less/more unique addresses {}'.format(result))
         for address in result:
             self.assertTrue(address in expected_result,
-                            "Failed composite of many delimiter cases")
+                            "Failed composite of many delimiter "
+                            "cases: {}".format(address))
 
-        # clean up needed #
         # case 8: single address passed
         address_str = '1110 Aspen Street NW'
         result = misc_tools.get_unique_addresses_from_str(address_str)
-        self.assertTrue(result, 'Failed - returned empty list')
-        self.assertEqual(len(result), 1, 'Incorrect number of addresses')
-        self.assertEqual(address_str, result.pop(),
-                         'Failed single address validation')
+        self.assertTrue(result, 'Failed single address - returned empty list')
+        self.assertEqual(len(result), 1,
+                         'Failed single address - returned less/more unique '
+                         'addresses {}'.format(result))
+        self.assertEqual(address_str, result[0],
+                         'Failed single address validation: {}'.format(
+                             result[0]))
+
+        # Messy cases involving commas #
+        # case 9a: simple comma delimited address numbers only
+        address_str = '6616, 6626 GEORGIA AVE NW'
+        expected_result = ['6616 GEORGIA AVE NW', '6626 GEORGIA AVE NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed single address number range comma '
+                                'delimiter - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed single address number range comma delimiter - '
+                         'returned less/more unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            "Failed single address number range comma "
+                            "delimiter case: {}".format(address))
+
+        # case 9b: comma delimited address numbers only
+        address_str = '6606, 6606, 6616, 6626 GEORGIA AVE NW'
+        expected_result = ['6606 GEORGIA AVE NW', '6606 GEORGIA AVE NW',
+                           '6616 GEORGIA AVE NW', '6626 GEORGIA AVE NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed multiple address number range comma '
+                                'delimiter - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed multiple address number range comma '
+                         'delimiter - returned less/more unique '
+                         'addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed multiple address number range comma '
+                            'delimiter case: {}'.format(address))
+
+        # case 9c: clean up unnecessary comma
+        address_str = '1864 CENTRAL PLACE, NE'
+        expected_result = ['1864 CENTRAL PLACE NE']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed remove extra comma - returned '
+                                'empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed remove extra comma - returned less/more '
+                         'unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed remove extra comma case: {}'.format(
+                                address))
+
+        # case 9d: comma delimited address numbers and street
+        address_str = '1860,1862,1864 CENTRAL PLACE, NE'
+        expected_result = ['1860 CENTRAL PLACE NE', '1862 CENTRAL PLACE NE',
+                           '1864 CENTRAL PLACE NE']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed remove extra comma + multiple address'
+                                ' number range comma delimiter - returned '
+                                'empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed remove extra comma + multiple address number '
+                         'range comma delimiter - returned less/more '
+                         'unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed remove extra comma + multiple address '
+                            'number range comma delimiter case: {}'.format(
+                                address))
+
+        # case 10a: remove extra comma and '-' number range composite case
+        address_str = '1210-1214 SOUTHERN AVE, S.E.'
+        expected_result = ['1210 SOUTHERN AVE S.E.',
+                           '1212 SOUTHERN AVE S.E.',
+                           '1214 SOUTHERN AVE S.E.']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed remove extra comma + "-" - returned '
+                                'empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed remove extra comma + "-" - returned less/more '
+                         'unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed remove extra comma + "-" case: {}'.format(
+                                address))
+
+        # case 10b: shorthand '-' delimiter and remove extra comma composite
+        address_str = '1210-14 SOUTHERN AVE, S.E.'
+        expected_result = ['1210 SOUTHERN AVE S.E.',
+                           '1212 SOUTHERN AVE S.E.',
+                           '1214 SOUTHERN AVE S.E.']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed shorthand "-" + remove extra comma '
+                                'composite - returned empty list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed shorthand "-" + remove extra comma - returned '
+                         'less/more unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed shorthand "-" + remove extra comma '
+                            'composite: {}'.format(address))
+
+        # case 11: '&' and comma delimiter composite
+        address_str = '24, 52, & 230 BATES ST NW'
+        expected_result = ['230 BATES ST NW', '24 BATES ST NW',
+                           '52 BATES ST NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed "&" + comma composite - returned empty '
+                                'list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed "&" and comma composite - returned less/more '
+                         'unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed "&" and comma composite: {}'.format(
+                                address))
+
+        # case 12: funky '&' case clean up and remove extra comma - invalid
+        # building address
+        address_str = 'HAYES STREET &ANACOSTIA AVENUE, NORTH EAST'
+        expected_result = ['HAYES STREET & ANACOSTIA AVENUE NORTH EAST']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed funky "&" clean up - returned empty '
+                                'list')
+        self.assertEqual(len(expected_result), len(result),
+                         'Failed funky "&" clean up - returned less/more '
+                         'unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed funky "&" clean up case: {}'.format(
+                                address))
+
+        # case 13: '-', '&', and comma address number range composite
+        address_str = '1416-1420,1432,1436 & 1440 R ST NW'
+        expected_result = ['1440 R ST NW', '1420 R ST NW',
+                           '1432 R ST NW', '1436 R ST NW',
+                           '1416 R ST NW', '1418 R ST NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed "-" + "&" + comma composite - returned '
+                                'empty list')
+        self.assertEqual(len(result), len(expected_result),
+                         'Failed "-" + "&" + comma composite - returned '
+                         'less/more unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed "-" + "&" + comma composite '
+                            'case: {}'.format(address))
+
+        # 'dirty' cases - return original string
+        # case 14a: invalid '&' with address number
+        address_str = '1416-1440 R & 14th ST NW'
+        expected_result = ['1416-1440 R & 14th ST NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed handling invalid "&" - '
+                                'returned empty list')
+        self.assertEqual(len(result), len(expected_result),
+                         'Failed handling invalid "&" - returned '
+                         'less/more unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed handling invalid "&" case: {}'.format(
+                                address))
+
+        # case 14b: invalid '&' (intersections)
+        address_str = 'HAYES STREET &ANACOSTIA AVENUE NORTH EAST'
+        expected_result = ['HAYES STREET &ANACOSTIA AVENUE NORTH EAST']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed handling invalid "&" - '
+                                'returned empty list')
+        self.assertEqual(len(result), len(expected_result),
+                         'Failed handling invalid "&" - returned '
+                         'less/more unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed handling invalid "&" case: {}'.format(
+                                address))
+
+        # case 15a: incomplete dash address number range
+        address_str = '1416- R ST NW'
+        expected_result = ['1416- R ST NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed incomplete dash address number - '
+                                'returned empty list')
+        self.assertEqual(len(result), len(expected_result),
+                         'Failed incomplete dash address number - returned '
+                         'less/more unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed incomplete dash address number '
+                            'case: {}'.format(address))
+
+        # case 15b: incomplete comma address number range
+        address_str = '1416, R ST NW'
+        expected_result = ['1416, R ST NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed incomplete comma address number - '
+                                'returned empty list')
+        self.assertEqual(len(result), len(expected_result),
+                         'Failed incomplete comma address number - returned '
+                         'less/more unique addresses {}'.format(result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed incomplete comma address number '
+                            'case: {}'.format(address))
+
+        # case 15c: incomplete ampersand address number range
+        address_str = '1416 & R ST NW'
+        expected_result = ['1416 & R ST NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed incomplete ampersand address number - '
+                                'returned empty list')
+        self.assertEqual(len(result), len(expected_result),
+                         'Failed incomplete ampersand address number - '
+                         'returned less/more unique addresses {}'.format(
+                             result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed incomplete ampersand address number '
+                            'case: {}'.format(address))
+
+        # case 16: multiple contiguous '-', '&', ',': assuming invalid address
+        address_str = '1416 && 1418 R ST NW; 1416--1418 R ST NW; ' \
+                      '1416,, 1418 R ST NW; 1416 &-, 1418 R ST NW'
+        expected_result = ['1416 && 1418 R ST NW', '1416--1418 R ST NW',
+                           '1416,, 1418 R ST NW', '1416 &-, 1418 R ST NW']
+        result = misc_tools.get_unique_addresses_from_str(address_str)
+        self.assertTrue(result, 'Failed multiple contiguous range delimiter - '
+                                'returned empty list')
+        self.assertEqual(len(result), len(expected_result),
+                         'Failed multiple contiguous range delimiter - '
+                         'returned less/more unique addresses {}'.format(
+                             result))
+        for address in result:
+            self.assertTrue(address in expected_result,
+                            'Failed multiple contiguous range delimiter '
+                            'case: {}'.format(address))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Updated 'get_unique_addresses_from_str()' to handle the following cases noted in #496:
- incomplete use of dash address
- comma separated numbers
- mixing of commas and & for numbers
- mixing of commas and dash separated numbers with &
- different meaning of &
- cleanly handles cases that may be considered invalid address: logs as invalid and returns original string

## Testing
Review cases in unit test, run to confirm all tests pass. Add additional test cases if I missed any edge cases and run unit test.