### PR TITLE
502 tabulate chart

### DIFF
--- a/docs/tool/css/project.css
+++ b/docs/tool/css/project.css
@@ -7,6 +7,7 @@
 	font-size: 15px;
     font-weight: bold;
     margin-bottom: 0px;
+    color: rgb(54,82,124);
 }
 
 .centered {
@@ -138,15 +139,15 @@
 	padding-right:10px;
 }
 
-.project-data-table td.title {
+.project-data-table td.title,
+.project-data-table thead td {
 	font-weight:bold;
 }
 
-.project-dat-atable td.value {
+.project-data-table td.value {
 	font-weight:normal;
 }
 
 .ui.attached.header {
 	background-color: rgb(237, 241, 247);
 }
-

--- a/docs/tool/index.html
+++ b/docs/tool/index.html
@@ -43,7 +43,7 @@
     <script src="js/charts/donut-chart-old.js"></script>
     <script src="js/charts/subsidy-timeline.js"></script>
     <script src="js/charts/bar-chart.js"></script>
-
+    <script src="js/charts/D3Table.js"></script>
 
     <link rel="stylesheet" type="text/css" href="css/external/semantic.min.css" />
     <link rel="stylesheet" type="text/css" href="css/external/icon.min.css" />

--- a/docs/tool/js/charts/D3Table.js
+++ b/docs/tool/js/charts/D3Table.js
@@ -99,34 +99,30 @@ D3Table.prototype = {
 
       HC.exit().remove()
 
-      //Add the data cells
+      //Add the data rows and cells (DRs, DCs)
       var DRs = chart._tbody.selectAll('tr')
         .data(chart.data());
       var newDRs = DRs.enter()
         .append('tr')
       var allDRs = newDRs.merge(DRs)
-        .selectAll('td')
+      var DCs = allDRs.selectAll('td')
         .data(function(row,i){
           return chart.columns().map(function(column){
             return {column:column, value:row[column['field']]}
           })
         })
 
-        .enter()
+      var newDCs = DCs.enter()
         .append('td')
+      var allDCs = newDCs.merge(DCs)  
         .html(function(d){
             var func = d.column.html
             return func(d.value)
           })
-        .attr("class", function(d) {
-          var existing = d3.select(this).attr("class") 
-          if (existing == null){
-            return d.column.class
-          }else{
-            return existing + " " + d.column.class
-          }
-        })
+        .attr("class", function(d) {return d.column.class}) //overwrites anything existing
 
+      DRs.exit().remove(); //remove out of date rows
+      DCs.exit().remove(); //remove out of date cells
 
     },      
     //TODO not used currently

--- a/docs/tool/js/charts/D3Table.js
+++ b/docs/tool/js/charts/D3Table.js
@@ -1,0 +1,185 @@
+"use strict";
+
+var D3Table = function(container) {    //chartOptions is an object, was DATA_FILE, el, field, sortField, asc, readableField                                                              
+/*
+Turns an array of objects into an html table. 
+
+Usage:
+data = [
+  {
+    "col1":"foo",
+    "col2":"bar"
+  },
+  {
+    "col1":"baz",
+    "col2":"bing"
+  },
+]
+
+var tbl = new D3Table('.containerDivSelectString')
+          .data(data)
+          .columns(['col1','col2'])
+          .create()
+
+You can also specify header values that are not the same as the key in the data object, and custom data formatting functions. 
+If the value of a column in the 'columns' list is a string, the label will be the same as the field and the data will be displayed as-is. 
+Columns can mix-and-match the string method or the object method, but if you use the object method you must specify the whole object.
+
+var columns = ['col1',
+          {field:'col2', 
+          label:'Second Column', 
+          class:'yoyo', 
+          html: function(d){return '$' + d}
+          }
+        ]
+
+tbl.columns(columns).update()
+
+*/
+    this.setup(container); 
+    return this;
+};
+
+D3Table.prototype = {
+    create: function(){
+      /*
+      This method is called to trigger drawing of the chart once all initial properties have been 
+      set using method chaining. Example:
+
+      myChart = new ChartProto('.myContainerSelector')
+                .width(500)
+                .height(200)
+                .create()
+      */
+      var chart = this
+      chart.update()
+      return chart
+    },
+    setup: function(container) {
+      /*
+      setup initializes all the default parameters, and create the container objects that are only created once. 
+      This method is run automatically when a new object is created
+      */
+
+      var chart = this; 
+
+      //Setup defaults
+      chart._data = []
+      chart._columns = []
+      chart._container = container
+      chart._delay = 200
+      chart._duration = 1000
+
+      chart._table = d3.select(container).append('table')
+      chart._thead = chart._table.append('thead')
+      chart._thead_row = chart._thead.append('tr')
+      chart._tbody = chart._table.append('tbody')
+      chart._tfoot = chart._table.append('tfoot')
+      chart._tfoot_row = chart._tfoot.append('tr')
+
+    },
+
+    resize: function(){
+      //Unused in this chart
+      return this
+    }, 
+    update: function(data){
+      /*
+      Put the data into the chart
+      */
+      var chart = this
+
+      //Add column headers cells (hc)
+      var HC = chart._thead_row.selectAll('td')
+          .data(chart.columns())
+      var newHC = HC.enter()
+                    .append('td')
+      var allHC = newHC.merge(HC)
+          .html(function(d){return d.label})
+
+      HC.exit().remove()
+
+      //Add the data cells
+      var DRs = chart._tbody.selectAll('tr')
+        .data(chart.data());
+      var newDRs = DRs.enter()
+        .append('tr')
+      var allDRs = newDRs.merge(DRs)
+        .selectAll('td')
+        .data(function(row,i){
+          return chart.columns().map(function(column){
+            return {column:column, value:row[column['field']]}
+          })
+        })
+
+        .enter()
+        .append('td')
+        .html(function(d){
+            var func = d.column.html
+            return func(d.value)
+          })
+        .attr("class", function(d) {
+          var existing = d3.select(this).attr("class") 
+          if (existing == null){
+            return d.column.class
+          }else{
+            return existing + " " + d.column.class
+          }
+        })
+
+
+    },      
+    //TODO not used currently
+    sort: function(field, direction) {
+        chart.data.sort(function(a, b) { 
+          if (direction === 'asc') return a[chartOptions.sort.field] - b[chartOptions.sort.field];
+          return b[chartOptions.sort.field] - a[chartOptions.sort.field]; 
+        });             
+    },
+
+    /*
+    Custom getter/setters
+    */
+    data: function(_){
+        if (!arguments.length) return this._data;
+        this._data = _;
+        return this;
+    },
+    columns: function(_){
+        if (!arguments.length) return this._columns;
+        for (var i = 0; i < _.length; i++) {
+
+          //If entry is just the column name, convert to object w/ defaults
+          if (typeof _[i] === 'string'){
+            _[i] = {"field":_[i],
+                    "label":_[i],
+                    "class":"",
+                    "html":function(d){return d}
+                  }
+          } else{
+            //do nothing - asssume in proper format. Could add validation here.
+          }
+        };
+        this._columns = _;
+        return this;
+    },
+
+    container: function(_){
+        if (!arguments.length) return this._container;
+        this._container = _;
+        return this;
+    },
+    delay: function(_){
+        if (!arguments.length) return this._delay;
+        this._delay = _;
+        return this;
+    },
+    duration: function(_){
+        if (!arguments.length) return this._duration;
+        this._duration = _;
+        return this;
+    }
+};
+
+
+

--- a/docs/tool/js/charts/D3Table.js
+++ b/docs/tool/js/charts/D3Table.js
@@ -67,6 +67,7 @@ D3Table.prototype = {
       chart._data = []
       chart._columns = []
       chart._container = container
+      chart._hideTitle = false
       chart._delay = 200
       chart._duration = 1000
 
@@ -83,21 +84,24 @@ D3Table.prototype = {
       //Unused in this chart
       return this
     }, 
-    update: function(data){
+    update: function(){
       /*
       Put the data into the chart
       */
       var chart = this
-
+      console.log(chart._data)
       //Add column headers cells (hc)
-      var HC = chart._thead_row.selectAll('td')
-          .data(chart.columns())
-      var newHC = HC.enter()
-                    .append('td')
-      var allHC = newHC.merge(HC)
-          .html(function(d){return d.label})
+      //TODO need to refactor - adding hideTitle and updating won't remove the title
+      if (!chart.hideTitle()) {
+        var HC = chart._thead_row.selectAll('td')
+            .data(chart.columns())
+        var newHC = HC.enter()
+                      .append('td')
+        var allHC = newHC.merge(HC)
+            .html(function(d){return d.label})
 
-      HC.exit().remove()
+        HC.exit().remove()
+      }
 
       //Add the data rows and cells (DRs, DCs)
       var DRs = chart._tbody.selectAll('tr')
@@ -163,6 +167,11 @@ D3Table.prototype = {
     container: function(_){
         if (!arguments.length) return this._container;
         this._container = _;
+        return this;
+    },
+    hideTitle: function(_){
+        if (!arguments.length) return this._hideTitle;
+        this._hideTitle = _;
         return this;
     },
     delay: function(_){

--- a/docs/tool/js/views/project-view.js
+++ b/docs/tool/js/views/project-view.js
@@ -1,5 +1,6 @@
 //A comment here helps keep Jekyll from getting confused about rendering
 
+
 "use strict";
 
 var projectView = {
@@ -32,6 +33,10 @@ var projectView = {
   renderSegments: function(){
     var nlihc_id = getState()['selectedBuilding'][0]['properties']['nlihc_id']
     var full_project_data = model.dataCollection['full_project_data_' + nlihc_id]['objects'][0]
+    
+    //save for later use
+    projectView.full_project_data = full_project_data;
+
     for(var segmentName in this.layout){
       this.wrapAndAppendSegment(this.layout[segmentName], full_project_data);
     }
@@ -177,7 +182,6 @@ var projectView = {
       hideTitle: true,
       wrapperPartial: 'partials/project-view/header.html',
       render: function(full_project_data){
-        console.log("full project data", full_project_data)
         var d = full_project_data;
         d3.select('#project-name').text(d.proj_name)
         d3.select('#project-address').text(d.proj_addre)
@@ -195,13 +199,45 @@ var projectView = {
       }
     },
     */
-    location: {
+    units: {
       //Several sections after this have title hidden, so this uses generic title above all of them
-      title:'Property Information',
-      wrapperPartial: 'partials/project-view/location.html',
+      title: 'Property Information',
+      wrapperPartial:'partials/project-view/units.html',
       hideTitle: false,
       render: function(full_project_data){
-        //
+          var data = [];
+          data.push({title:'Subsidized Units',value: full_project_data['proj_units_assist_max']})
+          data.push({title:'Total Units',value: (full_project_data['proj_units_tot'])})
+
+          var table = new D3Table('#units-table')
+            .data(data)
+            .columns([
+                {field:'title', label:'Title', class:'title', html: function(d){return d}},
+                {field:'value',label:'Value',class:'value',html:function(d){return d==null ? 'Unknown' : d}}
+                ])
+            .hideTitle(true)
+            .create()
+      }
+    },
+    location: {
+      title:'Location Information',
+      wrapperPartial: 'partials/project-view/location.html',
+      hideTitle: true,
+      render: function(full_project_data){
+          var data = [];
+          data.push({title:'Ward',value: full_project_data['ward']})
+          data.push({title:'Neighborhood Cluster',value: (full_project_data['neighborhood_cluster'] + ": " + full_project_data['neighborhood_cluster_desc'])})
+          data.push({title:'ANC',value: full_project_data['anc']})
+          data.push({title: 'Census Tract',value: full_project_data['census_tract']})
+
+
+          var table = new D3Table('#location-table')
+            .data(data)
+            .columns([
+                {field:'title', label:'Title', class:'title', html: function(d){return d}},
+                'value'])
+            .hideTitle(true)
+            .create()
       }
     },
     ownership: {
@@ -209,7 +245,44 @@ var projectView = {
       wrapperPartial: 'partials/project-view/ownership.html',
       hideTitle:true,
       render: function(full_project_data){
-        //
+          var data = [];
+          data.push({title:'Owner Type',value: full_project_data['proj_owner_type']})
+          data.push({title:'Owner',value: (full_project_data['hud_own_name'])})
+          data.push({title:'Manager Type',value: full_project_data['hud_mgr_type']})
+          data.push({title: 'Manager',value: full_project_data['hud_mg_name']})
+
+
+          var table = new D3Table('#ownership-table')
+            .data(data)
+            .columns([
+                {field:'title', label:'Title', class:'title', html: function(d){return d}},
+                {field:'value',label:'Value',class:'value',html:function(d){return d==null ? 'Unknown' : d}}
+                ])
+            .hideTitle(true)
+            .create()
+      }
+    },
+    saleActivity: {
+      title: 'Sale Activity',
+      wrapperPartial:'partials/project-view/saleActivity.html',
+      hideTitle:true,
+      render: function(full_project_data){
+        var data = full_project_data.real_property
+
+        if (data.length == 0 ) {
+          d3.select('#realPropertyTable')
+            .append('p')
+            .html('No sale activity available')
+        } else{
+        var table = new D3Table('#realPropertyTable')
+                            .data(data)
+                            .columns([
+                                {field:'rp_date', label:'Date', class:'value', html: function(d){return d}},
+                                {field:'rp_type', label:'Activity Type', class:'value', html: function(d){return d}},
+                                {field:'rp_desc', label:'Description',class:'value',html:function(d){return d;}},
+                                ])
+                            .create()
+        }
       }
     },
     topaNotices: {
@@ -282,6 +355,23 @@ var projectView = {
             width: 700,
             height: 300
         }); 
+
+        var data = full_project_data['subsidy']
+        console.log("subsidy data",data);
+        
+        new D3Table('#subsidy-table')
+            .data(data)
+            .columns([
+                
+                {field:'poa_end', label:'Scheduled End Date', class:'value', html: function(d){return d}},
+                {field:'poa_end_actual', label:'Actual End Date', class:'value', html: function(d){return d==null ? '-' : d}},
+                {field:'poa_start', label:'Start Date', class:'value', html: function(d){return d}},
+                {field:'units_assist', label:'Assisted Units', class:'value', html: function(d){return d}},
+                {field:'program', label:'Program', class:'value', html: function(d){return d}},
+                {field:'agency', label:'Agency', class:'value', html: function(d){return d}}
+              ])
+            .create();
+
       }
     },
     affordableHousingMap:{

--- a/docs/tool/partials/project-view/ownership.html
+++ b/docs/tool/partials/project-view/ownership.html
@@ -6,24 +6,9 @@
 
     <div class="col-sm-10">
         <h4>Owner</h4>
-        <table id="ownership-table" class="project-data-table">
-            <tr>
-                <td class="title">Owner type</td>
-                <td class="value">def</td>
-            <tr>
-            <tr>
-                <td class="title">Owner</td>
-                <td class="value">sss</td>
-            <tr>
-            <tr>
-                <td class="title">Manager type</td>
-                <td class="value">abc</td>
-            <tr>
-            <tr>
-                <td class="title">Manager</td>
-                <td class="value">xxx</td>
-            <tr>
-        </table>
+        <div id="ownership-table" class="project-data-table">
+          
+        </div>
 
     </div>
 </div>

--- a/docs/tool/partials/project-view/saleActivity.html
+++ b/docs/tool/partials/project-view/saleActivity.html
@@ -5,10 +5,7 @@
     </div>
 
     <div class="col-sm-10">
-        <h4>Location</h4>
-
-        <div id="location-table" class="project-data-table">
-        </div>
-
+        <h4>Sale Activity</h4>
+        <div id="realPropertyTable" class="project-data-table"></div>
     </div>
 </div>

--- a/docs/tool/partials/project-view/subsidy.html
+++ b/docs/tool/partials/project-view/subsidy.html
@@ -1,6 +1,10 @@
 <div class="subsidy-timeline-chart">
     <div class="row">
         <div class="col-sm-12">
+            <h4>Subsidies</h4>
+            <div id="subsidy-table" class="project-data-table"></div>
+        </div>
+        <div class="col-sm-12">
             <div id="subsidy-timeline-chart" class="d3-chart"></div> 
         </div>
         <div class="clearfix"></div>

--- a/docs/tool/partials/project-view/units.html
+++ b/docs/tool/partials/project-view/units.html
@@ -5,9 +5,9 @@
     </div>
 
     <div class="col-sm-10">
-        <h4>Location</h4>
-
-        <div id="location-table" class="project-data-table">
+        <h4>Units</h4>
+        <div id="units-table" class="project-data-table">
+          
         </div>
 
     </div>

--- a/docs/tool/test_tabulate.html
+++ b/docs/tool/test_tabulate.html
@@ -77,13 +77,26 @@
 
         var demoChart = new D3Table('.demoChart')
                             .data(data)
-                            .columns(['nlihc_id',{field:'rp_date', label:'Date of RP', class:'yoyo', html: function(d){return 'date: ' + d}}])
+                            .columns(['rp_type',{field:'rp_date', label:'Date of RP', class:'yoyo', html: function(d){return 'date: ' + d}}])
                             .create()
 
         setTimeout(function(){
-            demoChart.columns(['nlihc_id','ssl',{field:'rp_date', label:'Date of RP', class:'yoyo', html: function(d){return 'date: ' + d}}])
+            demoChart.columns(['rp_type','ssl',{field:'rp_date', label:'Date of RP', class:'yoyo', html: function(d){return 'date: ' + d}}])
                 .update()
         },2000)
+
+        setTimeout(function(){
+            demoChart.columns(['rp_type','ssl'])
+                .update()
+        },4000)
+
+
+        setTimeout(function(){
+            var copiedData = JSON.parse(JSON.stringify(data))
+            copiedData.splice(1,1)
+            demoChart.data(copiedData)
+                .update()
+        },6000)
     </script>
     </body>
 

--- a/docs/tool/test_tabulate.html
+++ b/docs/tool/test_tabulate.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+    <head>
+
+        <script src="js/external/offline-use/d3.min.js"></script>
+
+        <style> /* set the CSS */
+        .chart .values { fill:  rgba(234, 100, 2, 0.7); }
+
+        .chart .filler { fill: rgba(200,200,200,0.7); }
+
+        </style>
+    </head>
+    <body>
+        <h1>Demo of chart template</h1>
+        <div class="demoChart"></div>
+    <script src="js/charts/D3Table.js"></script>
+    <script>
+
+        //Example data from nlihc_id NL000004 "real property" field
+        var data = [
+                    {
+                      "id": "20f185f5-3885-4bae-8731-c2afa95a160d", 
+                      "nlihc_id": "NL000004", 
+                      "rp_date": "2001-05-31", 
+                      "rp_desc": "OTR: Sold to Parkfair Associates LLC; price: $693,769; sale type: Market.", 
+                      "rp_type": "OTR: Property sale", 
+                      "ssl": "2609    0822", 
+                      "unique_data_id": "prescat_real_property"
+                    }, 
+                    {
+                      "id": "b655524d-b720-415d-9304-746998d7db31", 
+                      "nlihc_id": "NL000004", 
+                      "rp_date": "2000-11-17", 
+                      "rp_desc": "NIDC: Property sold, distressed sale, Other.", 
+                      "rp_type": "NIDC: Foreclosure outcome", 
+                      "ssl": "2609    0822", 
+                      "unique_data_id": "prescat_real_property"
+                    }, 
+                    {
+                      "id": "e5c1dd06-18bf-4a70-b32e-4ce30e781a28", 
+                      "nlihc_id": "NL000004", 
+                      "rp_date": "2000-11-17", 
+                      "rp_desc": "OTR: Sold to 1611 Park Rd Tenants Assoc; price: $605,000; sale type: Foreclosure.", 
+                      "rp_type": "OTR: Property sale", 
+                      "ssl": "2609    0822", 
+                      "unique_data_id": "prescat_real_property"
+                    }, 
+                    {
+                      "id": "85a35497-dd58-4d16-a266-ecbd6933dfd3", 
+                      "nlihc_id": "NL000004", 
+                      "rp_date": "2000-09-21", 
+                      "rp_desc": "ROD: Notice of foreclosure (2000086047); issued by Askin A Bradley.", 
+                      "rp_type": "ROD: Foreclosure notice", 
+                      "ssl": "2609    0822", 
+                      "unique_data_id": "prescat_real_property"
+                    }, 
+                    {
+                      "id": "bd6ffaa3-a9ba-440c-9527-ccc4364c9bf5", 
+                      "nlihc_id": "NL000004", 
+                      "rp_date": "2000-08-07", 
+                      "rp_desc": "ROD: Notice of foreclosure (2000070627); issued by Askin A Bradley.", 
+                      "rp_type": "ROD: Foreclosure notice", 
+                      "ssl": "2609    0822", 
+                      "unique_data_id": "prescat_real_property"
+                    }, 
+                    {
+                      "id": "fb10cfd8-0774-49fc-a604-6803780ffe57", 
+                      "nlihc_id": "NL000004", 
+                      "rp_date": "1997-11-18", 
+                      "rp_desc": "ROD: Notice of foreclosure (9700073539); issued by Askin A Bradley.", 
+                      "rp_type": "ROD: Foreclosure notice", 
+                      "ssl": "2609    0822", 
+                      "unique_data_id": "prescat_real_property"
+                    }
+                  ]
+
+        var demoChart = new D3Table('.demoChart')
+                            .data(data)
+                            .columns(['nlihc_id',{field:'rp_date', label:'Date of RP', class:'yoyo', html: function(d){return 'date: ' + d}}])
+                            .create()
+
+        setTimeout(function(){
+            demoChart.columns(['nlihc_id','ssl',{field:'rp_date', label:'Date of RP', class:'yoyo', html: function(d){return 'date: ' + d}}])
+                .update()
+        },2000)
+    </script>
+    </body>
+
+</html>


### PR DESCRIPTION
Adds a D3Table to the charts section. This reusable chart takes data in the form of an array of objects (standard json representation of tabular data) and turns it into an html table with appripriate `<thead>`, `<tbody><tr><td>` and `<tfooter>` elements. Users can specify which columns should be shown, and a formatting function to be applied to the data for use in number formatting, adding $ , etc. 

Updating the column list or the data and running the `update()` command on the table appropriately adds/removes columns and rows to the data. 

Adds several tables to the project-view using this reusable chart and the existing filter endpoint. 
