### PR TITLE
Jo 501 finalize url encoding

### DIFF
--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -436,7 +436,7 @@ Others are working correctly.
     font-size: 1em;
 }
 
-#projects-list>div:hover, #building-view-segments div:hover {
+#projects-list>div:hover, #building-view-segments div:hover, #projects-list>div.projects-list-selected {
     background-color: #ddebff;
 }
 

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -420,6 +420,7 @@ Others are working correctly.
     font-weight:bold;
     font-size:1.2em;
     cursor: pointer;
+    color: #bd3621;
 }
 #projects-list>div, #building-view-segments div {
     overflow: hidden;
@@ -429,6 +430,7 @@ Others are working correctly.
     opacity: 0;
     cursor: pointer;
     border-bottom: 1px solid gray;
+    transition: background-color 0.2s linear;
 
 }
 #projects-list>div .project-title {
@@ -436,8 +438,12 @@ Others are working correctly.
     font-size: 1em;
 }
 
-#projects-list>div:hover, #building-view-segments div:hover, #projects-list>div.projects-list-selected {
+#projects-list>div:hover, #building-view-segments div:hover {
     background-color: #ddebff;
+}
+
+#projects-list>div.projects-list-selected {
+    background-color: #d69c93;
 }
 
 #projects-list>div.enter, #projects-list>div.update,

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -155,10 +155,13 @@ button.nullValuesToggleSubmit::before {
 #project-preview-group{
     flex: 0 1 auto;
     height: 350px;
+    padding-left: 16px;
+    padding-top: 10px;
 }
 #projects-list-group{
     flex: 1 1 auto; /*makes the list expand to fill rest of available space, while both preview and list shrink if needed*/
     height: 350px; /*need some basis for flexbox to not oversquish the other container*/
+    padding: 0;
 }
 
 .scroll-y {
@@ -429,8 +432,7 @@ Others are working correctly.
     margin-bottom: 0;
     opacity: 0;
     cursor: pointer;
-    border-bottom: 1px solid gray;
-    transition: background-color 0.2s linear;
+    position: relative;
 
 }
 #projects-list>div .project-title {
@@ -442,13 +444,18 @@ Others are working correctly.
     background-color: #ddebff;
 }
 
-#projects-list>div.projects-list-selected {
-    background-color: #d69c93;
+
+#projects-list>div.projects-list-selected:before {
+    content: '\025B2';
+    color: #bd3621;
+    position: absolute;
+    left: 1px;
+    top: 4px;
 }
 
 #projects-list>div.enter, #projects-list>div.update,
 #building-view-segments div.enter {
-    padding: 5px 4px;
+    padding: 5px 4px 5px 16px;
     max-height: 100px;
     opacity: 1;
 }

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -33,7 +33,7 @@ var router = {
         if (data.length === 0 || !data) {
             delete router.stateObj[msg];
         } else if ( msg.split('.')[0] === 'previewBuilding' ) {
-            router.stateObj['previewBuilding'] = data;
+            router.stateObj['previewBuilding'] = data[0];
         } else {
             router.stateObj[msg] = data;
         }
@@ -131,7 +131,7 @@ var router = {
                 .find(function(each){
                     return each.properties.nlihc_id === eachArray[1];
                 });
-                setState('previewBuilding', matchingRenderedProject);
+                setState('previewBuilding', [matchingRenderedProject]);
             
             } else {
                 dataChoice = dataChoices.find(function(obj){

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -100,7 +100,7 @@ var router = {
                 paramsArray.push('pb=' + router.stateObj['previewBuilding'].properties.nlihc_id);
             }
         }
-     //   console.log(paramsArray.join('&'));
+     
         return paramsArray.join('&').replace(/ /g,'_');
     },
     screenLoad: function(){
@@ -109,6 +109,7 @@ var router = {
     decodeState: function(){
         console.log("decoding state from URL");
         var stateArray = window.location.hash.replace('#/HI/','').split('&');
+
         stateArray.forEach(function(each){
             var dataChoice;
             var eachArray = each.split('=');
@@ -125,13 +126,14 @@ var router = {
                 setState('subNav.right', 'buildings');
             
             } else if ( eachArray[0] === 'pb' ) {
-                var matchingRenderedProject = mapView.map.queryRenderedFeatures({
+                setState('subNav.right', 'buildings');
+                var renderedProjects = mapView.map.queryRenderedFeatures({
                     layers: ['project','project-enter','project-exit', 'project-unmatched']
-                })
-                .find(function(each){
+                });
+                var matchingRenderedProject = renderedProjects.find(function(each){
                     return each.properties.nlihc_id === eachArray[1];
                 });
-                setState('previewBuilding', [matchingRenderedProject]);
+                setState('previewBuilding', [matchingRenderedProject,true]); // true = flag to scroll matching projects list
             
             } else {
                 dataChoice = dataChoices.find(function(obj){

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -9,6 +9,8 @@ var router = {
             ['filterValues', router.pushFilter],
             ['mapLayer', router.pushFilter],
             ['overlaySet', router.pushFilter],
+            ['subNav.right', router.pushFilter],
+            ['previewBuilding', router.pushFilter],
             ['clearState', router.clearOverlayURL]
         ]);        
         router.isFilterInitialized = true;
@@ -33,7 +35,6 @@ var router = {
             delete router.stateObj[msg];
         } else {
             router.stateObj[msg] = data;
-            console.log(router.stateObj);
         }
         router.setHash()
     },
@@ -92,6 +93,10 @@ var router = {
                     return router.stateObj.overlaySet.overlay === obj.source;
                 });
                 paramsArray.push( 'ol=' + dataChoice.short_name);
+            } else if ( key === 'subNav.right' && router.stateObj['subNav.right'] === 'buildings' ) {
+                paramsArray.push('sb=bdng');
+            } else if ( key === 'previewBuilding' ){
+                paramsArray.push('pb=' + router.stateObj['previewBuilding'].properties.nlihc_id);
             }
         }
      //   console.log(paramsArray.join('&'));
@@ -115,6 +120,18 @@ var router = {
                 router.openFilterControl(dataChoice.source); // can be replicated for non-overLay filters if
                                                              // we decide to url encode them and want them (or the
                                                              // last) opened on load
+            } else if ( eachArray[0] === 'sb' ){
+                setState('subNav.right', 'buildings');
+            
+            } else if ( eachArray[0] === 'pb' ) {
+                var matchingRenderedProject = mapView.map.queryRenderedFeatures({
+                    layers: ['project','project-enter','project-exit', 'project-unmatched']
+                })
+                .find(function(each){
+                    return each.properties.nlihc_id === eachArray[1];
+                });
+                setState('previewBuilding', matchingRenderedProject);
+            
             } else {
                 dataChoice = dataChoices.find(function(obj){
                     return obj.short_name === eachArray[0];

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -30,7 +30,7 @@ var router = {
     },
     pushFilter: function(msg, data){
         console.log(msg,data);
-        if (data.length === 0 || !data) {
+        if (data.length === 0 || !data || ( msg === 'subNav.right' && msg === 'charts') ) {
             delete router.stateObj[msg];
         } else if ( msg.split('.')[0] === 'previewBuilding' ) {
             router.stateObj['previewBuilding'] = data[0];

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -30,9 +30,10 @@ var router = {
     },
     pushFilter: function(msg, data){
         console.log(msg,data);
-        // TO DO: add handling for sidebar and preview pusher
-        if (data.length === 0) {
+        if (data.length === 0 || !data) {
             delete router.stateObj[msg];
+        } else if ( msg.split('.')[0] === 'previewBuilding' ) {
+            router.stateObj['previewBuilding'] = data;
         } else {
             router.stateObj[msg] = data;
         }
@@ -95,7 +96,7 @@ var router = {
                 paramsArray.push( 'ol=' + dataChoice.short_name);
             } else if ( key === 'subNav.right' && router.stateObj['subNav.right'] === 'buildings' ) {
                 paramsArray.push('sb=bdng');
-            } else if ( key === 'previewBuilding' ){
+            } else if ( key.split('.')[0] === 'previewBuilding' ){
                 paramsArray.push('pb=' + router.stateObj['previewBuilding'].properties.nlihc_id);
             }
         }

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -12,7 +12,9 @@ var router = {
             ['clearState', router.clearOverlayURL]
         ]);        
         router.isFilterInitialized = true;
-        if ( router.hasInitialFilterState ) router.decodeState();
+        if ( router.hasInitialFilterState ) {
+            router.decodeState();
+        }
     },
     initBuilding: function() {
         router.initialView = 'building';

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -834,12 +834,10 @@
         },
         scrollMatchingList: function(data){
                 var projectData = data[0];
-                console.log(projectData, projectData.properties.nlihc_id);
                 $('#projects-list .projects-list-selected').removeClass('projects-list-selected'); 
                 var $listItem = $('#projects-list #' + projectData.properties.nlihc_id);
                 $listItem.addClass('projects-list-selected');
                 
-                console.log($listItem.length);
                 if ( $listItem.length > 0 && data[1]) { // if the map has been filtered the listitem may no longer be in the DOM
                                                         // data[1] == false is the flag to not scroll
                     var difference = $listItem.offset().top - $('#projects-list-group').offset().top; 
@@ -1005,7 +1003,6 @@
             var data = allData.filter(function(feature) {
                 return feature.properties.matches_filters === true;
             });
-            console.log(data);
 
             d3.selectAll('.matching-count')
                 .text(data.length);
@@ -1063,7 +1060,6 @@
                 .remove();
 
             if ( getState().previewBuilding && getState().previewBuilding[0] ){
-                console.log('calling scroll from d3 append', getState().previewBuilding[0]);
                 setTimeout(function(){
                     mapView.scrollMatchingList(getState().previewBuilding[0]);
                 },1000);
@@ -1101,8 +1097,6 @@
         },
 
         highlightHoveredBuilding(msg, data) {
-            console.log(msg,data);
-            console.log('highlightHoveredBuilding');
             if ( getState().hoverBuildingList[1] ){ // if there's a previous hoverBuildingList state, clear the highlight
                 mapView.map.setFilter('project-highlight-hovered-' + getState().hoverBuildingList[1], ['==', 'nlihc_id', '']);
                 mapView.map.removeLayer('project-highlight-hovered-' + getState().hoverBuildingList[1]);
@@ -1133,7 +1127,6 @@
         },
         highlightPreviewBuilding(msg, data) {
             var projectData = data[0];
-            console.log('highlightPreviewBuilding');
             if ( getState().previewBuilding[1] ){ // if there's a previous previewBuilding state, clear the highlight
                 mapView.map.setFilter('project-highlight-preview-' + getState().previewBuilding[1][0].properties.nlihc_id, ['==', 'nlihc_id', '']);
                 mapView.map.removeLayer('project-highlight-preview-' + getState().previewBuilding[1][0].properties.nlihc_id);

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -1144,13 +1144,14 @@
                         'circle-blur': 0.2,
                         'circle-color': 'transparent',
                         'circle-radius': {
-                            'base': 1.75,
-                            'stops': [
-                                [12, 5],
-                                [15, 20]
-                            ]
-                        },
-                        'circle-stroke-width': 4,
+                                'base': 1.75,
+                                'stops': [
+                                    [11, 4],
+                                    [12, 5],
+                                    [15, 16]
+                                ]
+                            },
+                        'circle-stroke-width': 2,
                         'circle-stroke-opacity': 1,
                         'circle-stroke-color': '#bd3621'
                     },

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -69,14 +69,12 @@
                 // checks it against state of the project layer and 
                 // !isFilterInitialized to setState initialProjectsRendered. router.initFilters
                 // subscribes to that stateChange and turns isFilterInitialized to true so that this stateChange
-                // fires only once. adds a small delay for assurance
+                // fires only once. 
 
                 var theMap = this.map;
                 this.map.on('render', function() {
                   if ( theMap.loaded() && theMap.getLayer('project-enter') !== undefined && !router.isFilterInitialized ) {
-                      setTimeout(function(){
-                        setState('initialProjectsRendered', true);
-                    },250);
+                      setState('initialProjectsRendered', true);
                   }
                 });
 

--- a/docs/tool/js/views/results-view.js
+++ b/docs/tool/js/views/results-view.js
@@ -80,7 +80,6 @@ var resultsView = {
         console.log(raw_projects.length); // 1034
         //Update totals. TODO we only need to do this once, so we should move this elsewhere when we refactor this so it runs only on load. 
         for (var i = 0; i < raw_projects.length; i++) {
-            console.log(ward);
             if ( raw_projects[i]['ward'] !== null ) {
                 var ward = raw_projects[i]['ward']
                 var proj_units_assist_max = raw_projects[i]['proj_units_assist_max']

--- a/docs/tool/partials/map-view.html
+++ b/docs/tool/partials/map-view.html
@@ -117,9 +117,9 @@
             <div id="map"></div>
             <div id="category-legend" class="legend">
                 <div id="legend-items">
-                    <div><span class="square" style="background-color: rgba(253, 141, 60,0.5)"></span>Matches filters</div>
-                    <div><span class="square" style="background-color: #aaa"></span>Does not match filters</div>
-                    <div><span style="background-color: rgba(170,170,170,0.5); border: 2px solid #767676;"></span> or <span style="background-color: rgba(253, 141, 60,0.5); border: 2px solid #fc4203;"></span> Change since last filter</div>
+                    <div><span style="background-color: rgba(253, 141, 60,0.5)"></span>Matches filters</div>
+                    <div><span style="background-color: #aaa"></span>Does not match filters</div>
+                    <div><span style="border: 2px solid #fc4203;"></span>Selected building</div>
                 </div>
             </div>
 


### PR DESCRIPTION
— Fixes color coding not loading on URL decode
— Encodes/decodes navBar.right = buildings status
— Encodes/decodes previewBuilding

Third item got complicated and led to other things:

— checks that project layers have in fact been rendered before initializing the url decoding. That was the source of the timing issues
— marks the previewBuilding dot with a red ring
— changes legend to match that and to remove last-filter designations
— Zooms to selected previewBuilding and disables zoom-to-fit-filter-results functionality when there is a previewBuilding selected. It felt like unwanted behavior to have the map zoom away from a selected project. (TO DO: add a way to unselect the previewBuilding)
— scrolls the matching projects list to show the previewBuilding list item (if it matches filters). That reinforces the connection between the list and the map. Also adds up-triangle icon to indicate that that item is shown in the preview pane.
— scroll happens whether by clicking on the map or by url decode.

I did some pretty good stress testing, selecting lots of filters and a previewBuilding. Seems to be working well. For example: http://127.0.0.1:4000/tool/#/HI/sb=bdng&pb=8d6ec119-9534-4426-9b28-ce6d5e73101c&pa=1-28&pu=4-290&cv=82-430&pov=0.09-0.18&l=Ward_3 
