### PR TITLE
Move tool to Jekyll

### DIFF
--- a/docs/_includes/header-includes.html
+++ b/docs/_includes/header-includes.html
@@ -8,8 +8,12 @@
   {% endif %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<script src="{{ site.baseurl }}/js/external/jquery.js"></script>
-<script src="{{ site.baseurl }}/js/external/bootstrap.min.js"></script>
+<script
+  src="https://code.jquery.com/jquery-3.1.1.min.js"
+  integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
+  crossorigin="anonymous"></script>
+
+<!--script src="{{ site.baseurl }}/js/external/bootstrap.min.js"></script>-->
 
 
 <!-- Add to Calendar drop down button -->

--- a/docs/_includes/tool-footer.html
+++ b/docs/_includes/tool-footer.html
@@ -1,0 +1,5 @@
+<script src="js/core/router.js"></script>
+<script src="js/external/bootstrap.min.js"></script>
+<script src="js/external/semantic.min.js"></script>
+<script src="js/core/housing-insights.js"></script>
+<script src="js/external/papaparse.min.js"></script>

--- a/docs/_includes/tool-header.html
+++ b/docs/_includes/tool-header.html
@@ -1,0 +1,59 @@
+<meta charset="utf-8">
+
+<title>Housing Insights Tool</title>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.8.0/d3.min.js"></script>
+<script src='https://api.mapbox.com/mapbox-gl-js/v0.39.1/mapbox-gl.js'></script>
+<link href='https://api.mapbox.com/mapbox-gl-js/v0.39.1/mapbox-gl.css' rel='stylesheet' />
+
+<!--
+For use while working without internet
+<script src="js/external/offline-use/d3.min.js"></script>
+<script src="js/external/offline-use/mapbox-gl.js"></script>
+<script src="js/external/offline-use/jquery-3.1.1.min.js"></script>
+<link src="css/external/offline-use/mapbox-gl.css" rel="stylesheet" type="text/css" />
+
+ -->
+<script src="js/external/d3-tip.js"></script>
+<script scr="js/util/polyfills.js"></script>
+<script src="js/util/filter.js"></script>
+<script src="js/util/accordion.js"></script>
+<script src="js/util/exportCsv.js"></script>
+<script src="js/external/PubSub.js"></script>
+<script src="js/external/nouislider.js"></script>
+<script src="js/external/wNumb.js"></script>
+<script src="js/charts/chart-prototype.js"></script>
+<script src="js/views/map-view.js"></script>
+<script src="js/views/project-view.js"></script>
+<script src="js/views/results-view.js"></script>
+
+<script src="js/views/dataChoices.js"></script>
+<script src="js/views/filter-view.js"></script>
+
+
+<script src="js/views/chloropleth-legend.js"></script>
+<script src="js/charts/pie-chart-proto.js"></script>
+<script src="js/charts/donut-chart.js"></script>
+<script src="js/charts/donut-chart-old.js"></script>
+<script src="js/charts/subsidy-timeline.js"></script>
+<script src="js/charts/bar-chart.js"></script>
+<script src="js/charts/D3Table.js"></script>
+
+<link rel="stylesheet" type="text/css" href="css/external/semantic.min.css" />
+<link rel="stylesheet" type="text/css" href="css/external/icon.min.css" />
+
+<link href="css/external/nouislider.css" rel="stylesheet" />
+<link href="css/styles.css" rel="stylesheet" />
+<link href="css/filters.css" rel="stylesheet" />
+<link href="css/project.css" rel="stylesheet" type="text/css" />
+<link href="css/charts.css" rel="stylesheet" type="text/css" />
+
+<!--provided by header-includes.html
+
+<link href="css/bootstrap.css" rel="stylesheet" type="text/css" />
+<script
+  src="https://code.jquery.com/jquery-3.1.1.min.js"
+  integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
+  crossorigin="anonymous"></script>
+  -->
+  

--- a/docs/_layouts/toolLayout.html
+++ b/docs/_layouts/toolLayout.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<header>
+	{% include header-includes.html %}
+	{% include tool-header.html %}
+	{{page.css}}
+
+	<title>{{ page.title }}</title>
+
+</header>
+
+
+<!--Optional on-page styles-->
+<style>
+
+</style>
+
+
+
+<!--Main body of the content here-->
+<body>
+	{% include navbar.html %}
+	{{content}}
+
+	{{page.javascript}}
+
+	{% include tool-footer.html %}
+</body>
+
+</html>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -37,10 +37,11 @@ Much of this should be replaced with a bootstrap-theme.css file instead*/
   margin-top: -20px;
 }
 
+/* This caused super weird behavior in the semantic ui accordions
 .title-text{
   padding:10% 0
 }
-
+*/
 
 .hero-image h1,
 .hero-image h2 {
@@ -48,19 +49,6 @@ Much of this should be replaced with a bootstrap-theme.css file instead*/
   /*text-align: center;*/
 }
 
-.navbar{
-    background-color: var(--main-color);
-}
-
-.navbar-default .navbar-nav > li > a,
-.navbar-default .navbar-brand {
-	color: #ffffff;
-}
-
-.navbar-default .navbar-toggle .icon-bar {
-	background-color: #ffffff;
-  background-image: none;
-}
 
 
 a.disabled {
@@ -134,4 +122,31 @@ p {
 
 .calendar-link a {
   color: #198CFF
+}
+
+
+
+.navbar-nav > li > a, .navbar-brand {
+    padding: 4px 20px !important; 
+    height: 40px !important;
+    line-height: 26px !important;
+    font-size: 14px !important;
+    text-transform: capitalize !important;
+
+}
+
+.navbar {min-height:40px !important;}
+
+.navbar{
+    background-color: var(--main-color);
+}
+
+.navbar-default .navbar-nav > li > a,
+.navbar-default .navbar-brand {
+  color: #ffffff;
+}
+
+.navbar-default .navbar-toggle .icon-bar {
+  background-color: #ffffff;
+  background-image: none;
 }

--- a/docs/tool/css/styles.css
+++ b/docs/tool/css/styles.css
@@ -208,7 +208,7 @@ button.nullValuesToggleSubmit::before {
     display: block;
     left: 100%;
     height: 40px;
-    width: 200px;
+    width: 250px;
 
 }
 
@@ -550,38 +550,16 @@ Others are working correctly.
 
 
 #layer-menu-buttons button {
-        border: 5px solid #fff;
+    border: 5px solid #fff;
     padding: 9px 3px;
+    font-size: 11px;
 }
 
-/*
-Switched to semantic-ui buttons instead
-#layer-menu, #overlay-menu, #temp-filter-menu {
-    background: inherit;
-}
-#layer-menu, #overlay-menu {
-    width: 100%;
-}
-#layer-menu a, #overlay-menu a {
-    font-size: 13px;
-    color: #404040;
-    display: block;
-    margin: 0;
-    padding: 0;
-    padding: 10px;
-    text-decoration: none;
-    text-align: center;
-}
-a.unavailable {
-    background-color: rgb(220, 220, 220);
-    color: rgb(200, 200, 200);
-    pointer-events: none;
-}
-a.active {
-    background-color: #b3cde3;
-}
+#projects-list p,
+#filter-components p {
+    font-size:14px;
 
-*/
+}
 
 .no-location-alert {
     position: absolute;

--- a/docs/tool/index.html
+++ b/docs/tool/index.html
@@ -1,67 +1,16 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-
-    <title>Housing Insights Tool</title>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.8.0/d3.min.js"></script>
-    <script src='https://api.mapbox.com/mapbox-gl-js/v0.39.1/mapbox-gl.js'></script>
-    <link href='https://api.mapbox.com/mapbox-gl-js/v0.39.1/mapbox-gl.css' rel='stylesheet' />
-    <script
-      src="https://code.jquery.com/jquery-3.1.1.min.js"
-      integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
-      crossorigin="anonymous"></script>
-    <!--
-    For use while working without internet
-    <script src="js/external/offline-use/d3.min.js"></script>
-    <script src="js/external/offline-use/mapbox-gl.js"></script>
-    <script src="js/external/offline-use/jquery-3.1.1.min.js"></script>
-    <link src="css/external/offline-use/mapbox-gl.css" rel="stylesheet" type="text/css" />
-
-     -->
-    <script src="js/external/d3-tip.js"></script>
-    <script scr="js/util/polyfills.js"></script>
-    <script src="js/util/filter.js"></script>
-    <script src="js/util/accordion.js"></script>
-    <script src="js/util/exportCsv.js"></script>
-    <script src="js/external/PubSub.js"></script>
-    <script src="js/external/nouislider.js"></script>
-    <script src="js/external/wNumb.js"></script>
-    <script src="js/charts/chart-prototype.js"></script>
-    <script src="js/views/map-view.js"></script>
-    <script src="js/views/project-view.js"></script>
-    <script src="js/views/results-view.js"></script>
-
-    <script src="js/views/dataChoices.js"></script>
-    <script src="js/views/filter-view.js"></script>
+---
+layout: toolLayout
+title: Housing Insights - Tool
+---
 
 
-    <script src="js/views/chloropleth-legend.js"></script>
-    <script src="js/charts/pie-chart-proto.js"></script>
-    <script src="js/charts/donut-chart.js"></script>
-    <script src="js/charts/donut-chart-old.js"></script>
-    <script src="js/charts/subsidy-timeline.js"></script>
-    <script src="js/charts/bar-chart.js"></script>
-    <script src="js/charts/D3Table.js"></script>
-
-    <link rel="stylesheet" type="text/css" href="css/external/semantic.min.css" />
-    <link rel="stylesheet" type="text/css" href="css/external/icon.min.css" />
-
-    <link href="css/external/nouislider.css" rel="stylesheet" />
-    <link href="css/styles.css" rel="stylesheet" />
-    <link href="css/filters.css" rel="stylesheet" />
-    <link href="css/project.css" rel="stylesheet" type="text/css" />
-    <link href="css/bootstrap.css" rel="stylesheet" type="text/css" />
-    <link href="css/charts.css" rel="stylesheet" type="text/css" />
 
 
-</head>
-<body>
+<!--
 <div id="main-nav">
 Housing Insights (banner content / menu to come)
 </div>
-
+-->
     <div id="body-wrapper"></div>
 <div id="loading-state-screen">Loading saved state . . .</div>
 <!-- Modal -->
@@ -85,11 +34,5 @@ Housing Insights (banner content / menu to come)
 
     </div>
   </div>
-<script src="js/core/router.js"></script>
-<script src="js/external/bootstrap.min.js"></script>
-<script src="js/external/semantic.min.js"></script>
-<script src="js/core/housing-insights.js"></script>
-<script src="js/external/papaparse.min.js"></script>
-<!-- papaparse is used to create CSV export format. Can be removed if dont manually.  -->
-</body>
-</html>
+
+

--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -29,7 +29,7 @@ var router = {
         }
     },
     pushFilter: function(msg, data){
-        console.log(msg,data);
+        /*console.log(msg,data);*/
         if (data.length === 0 || !data || ( msg === 'subNav.right' && msg === 'charts') ) {
             delete router.stateObj[msg];
         } else if ( msg.split('.')[0] === 'previewBuilding' ) {

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -984,11 +984,12 @@ var filterView = {
         $('#filter-components').accordion({'exclusive':true, 'onOpen':function(){
             var difference = $( this ).offset().top - $('#filter-components').offset().top; 
             
+            /*for debug
             console.log($( this ).offset().top);
             console.log('vs');
             console.log($('#filter-components').offset().top);
             console.log(difference);
-            
+            */
               // if the accordion content extend below the bounds of the #filters container
             $('#filter-components').animate({
                 scrollTop: $( '#filter-components' ).scrollTop() + difference - 29
@@ -1136,7 +1137,7 @@ var filterView = {
             this.site = document.getElementById('clear-pillbox-holder');
 
             this.site.insertBefore(this.labelPill, this.site.firstChild);
-            this.labelPill.textContent = 'Filtered';
+            this.labelPill.textContent = 'Active Filters';
         },
         site: undefined,
         tearDown: function(){

--- a/docs/tool/js/views/results-view.js
+++ b/docs/tool/js/views/results-view.js
@@ -77,7 +77,6 @@ var resultsView = {
 
         //Note, accessing data collection directly to avoid aysnc nature of callback - we know this data set has been loaded because it's required for this function to be called
         var raw_projects = model.dataCollection['raw_project'].objects; 
-        console.log(raw_projects.length); // 1034
         //Update totals. TODO we only need to do this once, so we should move this elsewhere when we refactor this so it runs only on load. 
         for (var i = 0; i < raw_projects.length; i++) {
             if ( raw_projects[i]['ward'] !== null ) {
@@ -107,7 +106,6 @@ var resultsView = {
         //Calculate percents
         for (var i = 0; i < resultsView.filteredStats['ward'].length; i++) {
                 var d = resultsView.filteredStats['ward'][i]
-                console.log(d);
                 d.percent_projects = d['projects'] / d['total_projects']  //TODO protect against div0 error?
                 d.percent_proj_units_assist_max = d['proj_units_assist_max'] / d['total_proj_units_assist_max']
             };  


### PR DESCRIPTION
 Moves the tool/index.html content into a toolLayout.html and adds yaml front matter so that the tool is rendered via Jekyl

Fixes various CSS problems due to the conflict caused when the main.css and other sitewide files were introduced

Removes a few console.log statements to speed up performance.