### PR TITLE
Clean up logging

### DIFF
--- a/python/housinginsights/ingestion/Cleaners.py
+++ b/python/housinginsights/ingestion/Cleaners.py
@@ -7,7 +7,6 @@ values.
 from abc import ABCMeta, abstractclassmethod, abstractmethod
 from datetime import datetime
 import dateutil.parser as dateparser
-import logging
 import os
 from uuid import uuid4
 
@@ -20,6 +19,9 @@ from housinginsights.sources.models.mar import MAR_TO_TABLE_FIELDS
 
 PYTHON_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir,
                                            os.pardir))
+
+from housinginsights.tools.logger import HILogger
+logger = HILogger(name=__file__, logfile="ingestion.log")
 
 """
 Usage:
@@ -152,7 +154,7 @@ class CleanerBase(object, metaclass=ABCMeta):
             if value is None or value == self.null_value:
                 date = self.null_value
             else:
-                logging.warning("    Unable to format date properly: {}".format(value))
+                logger.warning("    Unable to format date properly: {}".format(value))
                 date = self.null_value
 
         return date
@@ -232,7 +234,7 @@ class CleanerBase(object, metaclass=ABCMeta):
         except KeyError:
             pass
             #this prints error for many rows with nulls.
-            logging.warning('  no matching Tract found for row {}'.format(
+            logger.warning('  no matching Tract found for row {}'.format(
                 row_num, row))
         return row
 
@@ -248,7 +250,7 @@ class CleanerBase(object, metaclass=ABCMeta):
         except KeyError:
             pass
             #this prints error for many rows with nulls.
-            logging.warning('  no matching Tract found for row {}'.format(row_num,row))
+            logger.warning('  no matching Tract found for row {}'.format(row_num,row))
         return row
 
     def rename_ward(self, row, ward_key='WARD'):
@@ -329,7 +331,7 @@ class CleanerBase(object, metaclass=ABCMeta):
                 first_address = address.split(';')[0]
                 result = mar_api.find_addr_string(first_address)
             except ValueError:
-                logging.info("ValueError in Mar for {} - returning none".format(row['Proj_addre']))
+                logger.info("ValueError in Mar for {} - returning none".format(row['Proj_addre']))
                 result = None
             
             if result:
@@ -665,7 +667,7 @@ class ProjectCleaner(CleanerBase):
             row = self.add_mar_id(row, 'Proj_address_id')
             row = self.add_geocode_from_mar(row=row)
         except Exception as e:
-            logging.error("Error geocoding {}, error was {}".format(row,e))
+            logger.error("Error geocoding {}, error was {}".format(row,e))
 
         row = self.rename_ward(row, ward_key='Ward2012')
         row = self.rename_status(row)

--- a/python/housinginsights/ingestion/functions.py
+++ b/python/housinginsights/ingestion/functions.py
@@ -2,7 +2,6 @@
 Module contains helper functions used in loading data into database
 """
 
-import logging
 import json
 from sqlalchemy.exc import ProgrammingError
 import sys
@@ -12,6 +11,9 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
                                              os.pardir, os.pardir)))
 
 import housinginsights.ingestion.Cleaners as Cleaners
+
+from housinginsights.tools.logger import HILogger
+logger = HILogger(name=__file__, logfile="ingestion.log")
 
 
 # Completed, tests not written.
@@ -50,7 +52,7 @@ def load_meta_data(filename='meta.json'):
     except:
         raise ValueError("Error found in JSON, check expected format.")
 
-    logging.info("{} imported. JSON format is valid: {}".format(filename, json_is_valid))
+    logger.info("{} imported. JSON format is valid: {}".format(filename, json_is_valid))
 
     return meta
 
@@ -106,7 +108,7 @@ def check_or_create_sql_manifest(engine, rebuild=False):
             create_command = "CREATE TABLE manifest({});".format(field_command)
             db_conn.execute(create_command)
             db_conn.close()
-            logging.info("Manifest table created in the SQL database")
+            logger.info("Manifest table created in the SQL database")
             return True
 
         except Exception as e:

--- a/python/housinginsights/sources/DCHousing.py
+++ b/python/housinginsights/sources/DCHousing.py
@@ -12,7 +12,7 @@ from housinginsights.sources.models.DCHousing import PROJECT_FIELDS_MAP,\
     SUBSIDY_FIELDS_MAP
 from housinginsights.tools.logger import HILogger
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 class DCHousingApiConn(ProjectBaseApiConn):
     """

--- a/python/housinginsights/sources/base.py
+++ b/python/housinginsights/sources/base.py
@@ -16,7 +16,7 @@ import csv
 import os
 from housinginsights.tools.logger import HILogger
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 class BaseApiConn(object):
 

--- a/python/housinginsights/sources/cama.py
+++ b/python/housinginsights/sources/cama.py
@@ -12,7 +12,7 @@ sys.path.append(PYTHON_PATH)
 from housinginsights.sources.base import BaseApiConn
 from housinginsights.tools.logger import HILogger
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 class MarApiConn_2(BaseApiConn):
     """

--- a/python/housinginsights/sources/census.py
+++ b/python/housinginsights/sources/census.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 from housinginsights.sources.base import BaseApiConn
 from housinginsights.tools.logger import HILogger
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 class CensusApiConn(BaseApiConn):
     """

--- a/python/housinginsights/sources/dhcd.py
+++ b/python/housinginsights/sources/dhcd.py
@@ -24,10 +24,6 @@ from xmljson import parker as xml_to_json
 
 import json
 
-from housinginsights.tools.logger import HILogger
-
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
-
 from housinginsights.sources.base_project import ProjectBaseApiConn
 from housinginsights.sources.models.dhcd import APP_ID, TABLE_ID_MAPPING, \
                                                         APP_METADATA_FIELDS, \
@@ -39,7 +35,7 @@ from housinginsights.sources.models.dhcd import APP_ID, TABLE_ID_MAPPING, \
 INCLUDE_ALL_FIELDS = True
 
 from housinginsights.tools.logger import HILogger
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 class DhcdApiConn(ProjectBaseApiConn):
     """

--- a/python/housinginsights/sources/google_maps.py
+++ b/python/housinginsights/sources/google_maps.py
@@ -1,7 +1,7 @@
 from housinginsights.sources.base import BaseApiConn
 from housinginsights.tools.logger import HILogger
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 class GoogleMapsApiConn(BaseApiConn):
     """

--- a/python/housinginsights/sources/mar.py
+++ b/python/housinginsights/sources/mar.py
@@ -5,7 +5,7 @@ from housinginsights.sources.base import BaseApiConn
 from housinginsights.sources.models.mar import MarResult, FIELDS
 from housinginsights.tools.logger import HILogger
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 
 class MarApiConn(BaseApiConn):

--- a/python/housinginsights/sources/opendata.py
+++ b/python/housinginsights/sources/opendata.py
@@ -9,7 +9,7 @@ if __name__ == '__main__':
 from housinginsights.sources.base import BaseApiConn
 from housinginsights.tools.logger import HILogger
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 class OpenDataApiConn(BaseApiConn):
     """

--- a/python/housinginsights/sources/prescat.py
+++ b/python/housinginsights/sources/prescat.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 from housinginsights.sources.base_project import ProjectBaseApiConn
 from housinginsights.tools.logger import HILogger
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 
 

--- a/python/housinginsights/sources/wmata_distcalc.py
+++ b/python/housinginsights/sources/wmata_distcalc.py
@@ -13,7 +13,7 @@ import housinginsights.tools.dbtools as dbtools
 from housinginsights.tools.logger import HILogger
 import sqlalchemy
 
-logger = HILogger(name=__file__, logfile="sources.log", level=10)
+logger = HILogger(name=__file__, logfile="sources.log")
 
 class WmataApiConn(BaseApiConn):
 

--- a/python/housinginsights/tools/logger.py
+++ b/python/housinginsights/tools/logger.py
@@ -22,6 +22,8 @@ class HILogger():
 
         # Create Logger, Formatter, and StreamHandler
         logger = logging.getLogger(os.path.basename(name))
+        logger.handlers = []
+
         logger.setLevel(level)
         formatter = logging.Formatter(  fmt=fmt,
                                         datefmt=datefmt)
@@ -34,6 +36,7 @@ class HILogger():
             logger.addHandler(file_handler)
 
         self.logger = logger
+
 
     def debug(self, msg, *args, **kwargs):
         self.logger.debug(msg, *args, **kwargs)

--- a/python/scripts/experimental.py
+++ b/python/scripts/experimental.py
@@ -1,0 +1,16 @@
+import time
+import sys
+import os
+import argparse
+
+PYTHON_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                           os.pardir))
+sys.path.append(PYTHON_PATH)
+
+from housinginsights.tools.logger import HILogger
+
+logger = HILogger(name=__file__, logfile="ingestion.log")
+
+for idx, value in enumerate(range(4)):
+    logger.warning("Hi!")
+    time.sleep(1)

--- a/python/scripts/load_data.py
+++ b/python/scripts/load_data.py
@@ -7,7 +7,6 @@ Utility function for running the LoadData class
 #################################
 import sys
 import os
-import logging
 import argparse
 
 PYTHON_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
@@ -15,14 +14,6 @@ PYTHON_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
 sys.path.append(PYTHON_PATH)
 
 from housinginsights.ingestion.LoadData import LoadData, main, parser
-
-# configuration: see /logs/example-logging.py for usage examples
-logging_path = os.path.abspath(os.path.join(PYTHON_PATH, "logs"))
-logging_filename = os.path.abspath(os.path.join(logging_path, "ingestion.log"))
-logging.basicConfig(filename=logging_filename, level=logging.INFO)
-
-# Pushes everything from the logger to the command line output as well.
-logging.getLogger().addHandler(logging.StreamHandler())
 
 #For command line arguments available, see the 'parser' at end of LoadData.py
 


### PR DESCRIPTION
-Removes the logging level from the init params of the logger, resulting in the use of the default. This lets us specify the logging level in just one place. Set new level to info instead of debug.

- Remove all references to 'logging' so that a second stream handler is not created, making the logging easier to read.
- Adds a counter to the cleaner since debug level messages are no longer shown.