### PR TITLE
Error handling and moving drop data until after cleaning

### DIFF
--- a/python/housinginsights/ingestion/DataReader.py
+++ b/python/housinginsights/ingestion/DataReader.py
@@ -369,29 +369,18 @@ class DataReader(HIReader):
 
     def _check_include_flag(self, sql_manifest_row):
         """
-        Internal function compares manifest from the csv to manifest in the
-        database. If the manifest says the file should be used ("use") AND the
-        file is not already loaded into the database (as indicated by the
-        matching sql_manifest_row), the file will be added.
+        Checks to make sure the include_flag matches requirements for loading the data
 
-        The sql object in charge of getting the sql_manifest_row and writing
-        new sql_manifest_row elements to the database is in charge of making
-        sure that the sql_manifest_row['status'] field can be trusted as a true
-        representation of what is in the database currently.
+        Previously this compared the manifest_row to the sql_manifest_row; however,
+        since the unique_data_id now stays constant across time this check is 
+        not needed. 
         """
 
         if self.manifest_row['include_flag'] == 'use':
-            if sql_manifest_row is None:  # okay if data isn't already in db
-                return True
-            # TODO: make this into if/else statement?
-            if sql_manifest_row['status'] != 'loaded':
-                return True
-            if sql_manifest_row['status'] == 'loaded':
-                logger.info("  {} is already in the database, skipping".format(
-                                self.manifest_row['unique_data_id']))
-                return False
+           return True
+
         else:
-            logger.info("  {} include_flag is {}, skipping".format(
+            logger.warning("Skipping data source. {} include_flag is {}".format(
                 self.manifest_row['unique_data_id'],
                 self.manifest_row['include_flag']))
             return False


### PR DESCRIPTION
This takes a few steps towards making our data loading process more robust

- Adds a "debug" mode to the LoadData class (in the __init__ params). If debug mode is true, errors are raised when they occur.
- Wraps the row-level cleaning in a try/except function; if it fails, write an error to the logs, and if in debug mode reraise the error
- Stronger warning (logger.error) when data can't be deleted from the database, and raises the exception if in debug mode. @pfjel7 this would help alert you to the problem that you encountered of an open connection preventing dropping of the table and ending up with duplicate rows. Not complete though - we should work more on this so that it prevents the new data from coming in if the data couldn't be dropped. 
- Moves the deletion of data to occur after data cleaning so that it is just before data loading, instead of having time inbetween when no data  is in the database.
- Eliminates the requirement for the sql manifest row to have status !=loaded. This is an old requirement from when the unique_data_id was meant to correspond to one specific file. In our current configuration, the unique_data_id is constant across all copies of the same data set, so even if it is loaded if we are running the function it means we want to overwrite that dataset. This requirement was essentially unused due to the fact that we deleted the data from the database before checking the sql manifest, so it was impossible to trigger in the previous code but moving the timing of data deletion has changed that