### PR TITLE
499 Add 'copy filter names' button

### DIFF
--- a/docs/tool/index.html
+++ b/docs/tool/index.html
@@ -32,6 +32,7 @@ Housing Insights (banner content / menu to come)
           </table>
         </div>
         <div class="modal-footer">
+          <button type="button" id="copyFilterNames" class="btn btn-default">Copy Filter Names</button>
           <button type="button" id="exportCsv" class="btn btn-default">Export to CSV</button>
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         </div>

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -1098,6 +1098,8 @@
               var continuousColumns = ['Filter', 'Min', 'Max', 'Include Nulls'];
               var categoricalColumns = ['Filter', 'Included Categories'];
 
+              console.log("&&& activeFilters", activeFilters);
+
               if ( continuousFilters.length > 0 ){
 
                 var continuousThead = continuousFiltersTable.append('thead')
@@ -1158,7 +1160,21 @@
                     .text(function (d) { return d.value; });
               }
 
-          });
+            });
+          d3.select('#copyFilterNames')
+            .on('click', function(d){
+                var activeFilters = filterUtil.getActiveFilterValues();
+                var filterTitlesOnly = [].concat.apply([], activeFilters.map(function(objArray){
+                    return objArray.map(function(obj){ return obj.Filter; });
+                }));
+                function setClipBoardToFilterTitleList(event){
+                    event.clipboardData.setData('text/plain', filterTitlesOnly.join("\n "));
+                    event.preventDefault();
+                }
+                document.body.addEventListener('copy', setClipBoardToFilterTitleList);
+                document.execCommand('copy');
+                document.body.removeEventListener('copy', setClipBoardToFilterTitleList);
+            });
         },
         exportButton: function() {
           d3.select('#exportCsv')


### PR DESCRIPTION
Addresses #499 and #501 

I've added a button to the Export CSV modal that copies to the clipboard a list of the names of active filters.

An alternative approach would have been to list the names of the filters directly within the modal. Since the modal already presents the names and values of filters as a table, I didn't want to double the on-screen real estate of the filter titles.

Since the functionality of the D3 Export CSV button comes from some D3-style procedural code inside addExportButton (within map-view.js), I've put the code for the 'copy filter titles' button there.