### PR TITLE
WIP fixing DHCD data download

### DIFF
--- a/python/housinginsights/sources/base.py
+++ b/python/housinginsights/sources/base.py
@@ -107,7 +107,7 @@ class BaseApiConn(object):
         else:
             url = urlpath
 
-        logger.debug("Requested URL %s with params %s", url, params)
+        logger.info("Requested URL %s with params %s", url, params)
         return self.session.get(url, params=params, proxies=self.proxies, **kwargs)
 
     def post(self, urlpath, data=None, **kwargs):

--- a/python/housinginsights/sources/dhcd.py
+++ b/python/housinginsights/sources/dhcd.py
@@ -32,7 +32,15 @@ from housinginsights.sources.models.dhcd import APP_ID, TABLE_ID_MAPPING, \
                                                         PROJECT_FIELDS_MAP,\
                                                         SUBSIDY_FIELDS_MAP
 
-INCLUDE_ALL_FIELDS = True
+
+
+# TODO include_all_fields properly switches which fields are requested to be a more extensive list
+# However, for the DHCD "project" table (equivalent to Housing Insights 'subsidy' table), the 
+# query then results in a 'Report too large' error (errcode 75). IF we want to enable this field, 
+# we will need to enable chunking the request using the record ids.
+# info: https://community.quickbase.com/quickbase/topics/suggestion-to-work-around-when-report-too-large-maximum-number-of-bytes-in-report-exceeded-error
+
+INCLUDE_ALL_FIELDS = {'dhcd_dfd_projects': False, 'dhcd_dfd_properties':True}
 
 from housinginsights.tools.logger import HILogger
 logger = HILogger(name=__file__, logfile="sources.log")
@@ -112,10 +120,10 @@ class DhcdApiConn(ProjectBaseApiConn):
         if INCLUDE_ALL_FIELDS:
             self._get_metadata()
         else:
-            self._get_metadata(default_display_only=True)
+            self._get_metadata()
 
 
-    def _get_metadata(self, default_display_only=False):
+    def _get_metadata(self):
         """
         Retrieves metadata about the DHCD DFD Quick Base app and its member tables
         (including field metadata and relationships) and saves this in two CSV files.
@@ -123,11 +131,6 @@ class DhcdApiConn(ProjectBaseApiConn):
         Also, for each unique data id corresponding to a table, (1) builds a field
         reference list of all relevant fields, and (2) sets the query parameter string
         (including the sort field parameter) used when saving table data in get_data(...).
-
-        :param default_display_only: Indicates whether or not to only include default
-                                     display fields in the field reference list;
-                                     default is False (gets all available table fields).
-        :type  default_display_only: Boolean.
         """
         output_path_dir = os.path.dirname(self.output_paths[self._available_unique_data_ids[0]])
         output_path_app_metadata = os.path.join(output_path_dir, '_dhcd_dfd_app_metadata.csv')
@@ -139,6 +142,7 @@ class DhcdApiConn(ProjectBaseApiConn):
         app_metadata = OrderedDict()
         table_metadata = OrderedDict()
         field_count = 0
+
         for app_table_metadata in app_tables_metadata_xml:
 
             table_dbid = app_table_metadata.text
@@ -158,131 +162,132 @@ class DhcdApiConn(ProjectBaseApiConn):
                     unique_data_id = 'dhcd_dfd_' + table_name_snake_case
                     self._fields[unique_data_id] = []
 
-                table_metadata_xml_fields = table_metadata_xml_root.findall('./table/fields/field')
-                table_metadata[table_dbid] = OrderedDict()
-                field_line_start = field_count + 2
+                    table_metadata_xml_fields = table_metadata_xml_root.findall('./table/fields/field')
+                    table_metadata[table_dbid] = OrderedDict()
+                    field_line_start = field_count + 2
 
-                for field_xml in table_metadata_xml_fields:
+                    for field_xml in table_metadata_xml_fields:
 
-                    fid = int(field_xml.get('id'))
-                    table_metadata[table_dbid][fid] = OrderedDict()
+                        fid = int(field_xml.get('id'))
+                        table_metadata[table_dbid][fid] = OrderedDict()
 
-                    field_label = field_xml.find('label').text
-                    field_name = field_label.lower().translate(self._identifier_translation_map)
+                        field_label = field_xml.find('label').text
+                        field_name = field_label.lower().translate(self._identifier_translation_map)
 
-                    # For any fields that belong to composite fields (e.g. address component fields),
-                    # resolve the full field name by prepending the parent field name
-                    parent_fid = None
-                    if field_xml.find('parentFieldID') is not None:
-                        parent_fid = int(field_xml.find('parentFieldID').text)
-                        if parent_fid in table_metadata[table_dbid]:
-                            parent_field_name = table_metadata[table_dbid][parent_fid]['field_name']
+                        # For any fields that belong to composite fields (e.g. address component fields),
+                        # resolve the full field name by prepending the parent field name
+                        parent_fid = None
+                        if field_xml.find('parentFieldID') is not None:
+                            parent_fid = int(field_xml.find('parentFieldID').text)
+                            if parent_fid in table_metadata[table_dbid]:
+                                parent_field_name = table_metadata[table_dbid][parent_fid]['field_name']
+                            else:
+                                parent_field_label = table_metadata_xml_root.find("./table/fields/field[@id='{}']/label".format(str(parent_fid))).text
+                                parent_field_name = parent_field_label.lower().translate(self._identifier_translation_map)
+                            if parent_field_name[0].isdigit():
+                                parent_field_name = '_' + parent_field_name
+                            field_name = '__'.join([parent_field_name, field_name])
+
+                        if field_name[0].isdigit():
+                            field_name = '_' + field_name
+
+                        # For any composite fields (e.g. address fields), get child/component fields
+                        child_fids = []
+                        for child_field in field_xml.findall('./compositeFields/compositeField'):
+                            child_fids.append(child_field.get('id'))
+                        child_fids = '|'.join(child_fids) if len(child_fids) > 0 else None
+
+                        table_metadata[table_dbid][fid]['table_name'] = table_name
+                        table_metadata[table_dbid][fid]['field_name'] = field_name
+                        table_metadata[table_dbid][fid]['field_label'] = field_label
+                        table_metadata[table_dbid][fid]['field_id'] = str(fid)
+                        table_metadata[table_dbid][fid]['field_type'] = field_xml.get('field_type')
+                        table_metadata[table_dbid][fid]['base_type'] = field_xml.get('base_type')
+                        table_metadata[table_dbid][fid]['appears_by_default'] = field_xml.find('appears_by_default').text
+
+                        table_metadata[table_dbid][fid]['composite_field_parent_fid'] = parent_fid
+                        table_metadata[table_dbid][fid]['composite_field_child_fids'] = child_fids
+
+                        table_metadata[table_dbid][fid]['mode'] = field_xml.get('mode')
+
+                        table_metadata[table_dbid][fid]['formula'] = None
+                        if field_xml.find('formula') is not None:
+                            table_metadata[table_dbid][fid]['formula'] = field_xml.find('formula').text
+
+                        table_metadata[table_dbid][fid]['choices'] = None
+                        if field_xml.find('choices') is not None:
+                            table_metadata[table_dbid][fid]['choices'] = ""
+                            for choice in field_xml.findall('./choices/choice'):
+                                table_metadata[table_dbid][fid]['choices'] += "\n" + choice.text \
+                                                        if len(table_metadata[table_dbid][fid]['choices']) > 0 \
+                                                        else choice.text
+
+                        table_metadata[table_dbid][fid]['lookup_target_fid'] = None
+                        table_metadata[table_dbid][fid]['lookup_source_fid'] = None
+                        if table_metadata[table_dbid][fid]['mode'] == 'lookup':
+                            if field_xml.find('lutfid') is not None:
+                                table_metadata[table_dbid][fid]['lookup_target_fid'] = field_xml.find('lutfid').text
+                            if field_xml.find('lusfid') is not None:
+                                table_metadata[table_dbid][fid]['lookup_source_fid'] = field_xml.find('lusfid').text
+
+                        table_metadata[table_dbid][fid]['dblink_target_dbid'] = None
+                        table_metadata[table_dbid][fid]['dblink_target_fid'] = None
+                        table_metadata[table_dbid][fid]['dblink_source_fid'] = None
+                        if table_metadata[table_dbid][fid]['mode'] == 'virtual' and \
+                            table_metadata[table_dbid][fid]['field_type'] == 'dblink':
+                            if field_xml.find('target_dbid') is not None:
+                                table_metadata[table_dbid][fid]['dblink_target_dbid'] = field_xml.find('target_dbid').text
+                            if field_xml.find('target_fid') is not None:
+                                table_metadata[table_dbid][fid]['dblink_target_fid'] = field_xml.find('target_fid').text
+                            if field_xml.find('source_fid') is not None:
+                                table_metadata[table_dbid][fid]['dblink_source_fid'] = field_xml.find('source_fid').text
+                        table_metadata[table_dbid][fid]['fkey_table_app_dbid'] = None
+                        table_metadata[table_dbid][fid]['fkey_table_alias'] = None
+                        if field_xml.find('mastag') is not None:
+                            fkey_ref = field_xml.find('mastag').text.split('.')
+                            if len(fkey_ref) == 2:
+                                table_metadata[table_dbid][fid]['fkey_table_app_dbid'] = fkey_ref[0]
+                                table_metadata[table_dbid][fid]['fkey_table_alias'] = fkey_ref[1].lower()
+                            else:
+                                table_metadata[table_dbid][fid]['fkey_table_app_dbid'] = None
+                                table_metadata[table_dbid][fid]['fkey_table_alias'] = fkey_ref[0].lower()
+
+                        table_metadata[table_dbid][fid]['field_help'] = field_xml.find('fieldhelp').text
+
+                        # For each unique data id corresponding to a table,
+                        # build a list of all relevant fields
+                        if unique_data_id is not None and \
+                            (INCLUDE_ALL_FIELDS[unique_data_id] or \
+                             table_metadata[table_dbid][fid]['appears_by_default'] == '1'):
+                            self._fields[unique_data_id].append(field_name)
+
+                        field_count += 1
+
+                    field_line_end = field_count + 1
+
+                    app_metadata[table_dbid] = OrderedDict([
+    					  ('table_name',                table_name),
+                          ('table_dbid',                table_dbid),
+                          ('table_alias',               app_table_metadata.get('name')),
+                          ('key_fid',                   table_metadata_xml_orig.find('key_fid').text),
+                          ('default_sort_fid',          table_metadata_xml_orig.find('def_sort_fid').text),
+                          ('default_sort_order',        table_metadata_xml_orig.find('def_sort_order').text),
+                          ('single_record_name',        table_metadata_xml_orig.find('single_record_name').text),
+                          ('plural_record_name',        table_metadata_xml_orig.find('plural_record_name').text),
+                          ('field_metadata_line_start', field_line_start),
+                          ('field_metadata_line_end',   field_line_end)
+                        ])
+
+                    if unique_data_id is not None and unique_data_id in self._fields:
+                        # While not strictly a field, Quick Base always includes final 'update_id':
+                        self._fields[unique_data_id].append('update_id')
+                        # Set the query parameter string (including the sort field parameter):
+                        if INCLUDE_ALL_FIELDS[unique_data_id]:
+                            self._params[unique_data_id] = DhcdApiConn.PARAMS_DATA_ALL_FIELDS
                         else:
-                            parent_field_label = table_metadata_xml_root.find("./table/fields/field[@id='{}']/label".format(str(parent_fid))).text
-                            parent_field_name = parent_field_label.lower().translate(self._identifier_translation_map)
-                        if parent_field_name[0].isdigit():
-                            parent_field_name = '_' + parent_field_name
-                        field_name = '__'.join([parent_field_name, field_name])
+                            self._params[unique_data_id] = DhcdApiConn.PARAMS_DATA_DEFAULT_FIELDS
 
-                    if field_name[0].isdigit():
-                        field_name = '_' + field_name
-
-                    # For any composite fields (e.g. address fields), get child/component fields
-                    child_fids = []
-                    for child_field in field_xml.findall('./compositeFields/compositeField'):
-                        child_fids.append(child_field.get('id'))
-                    child_fids = '|'.join(child_fids) if len(child_fids) > 0 else None
-
-                    table_metadata[table_dbid][fid]['table_name'] = table_name
-                    table_metadata[table_dbid][fid]['field_name'] = field_name
-                    table_metadata[table_dbid][fid]['field_label'] = field_label
-                    table_metadata[table_dbid][fid]['field_id'] = str(fid)
-                    table_metadata[table_dbid][fid]['field_type'] = field_xml.get('field_type')
-                    table_metadata[table_dbid][fid]['base_type'] = field_xml.get('base_type')
-                    table_metadata[table_dbid][fid]['appears_by_default'] = field_xml.find('appears_by_default').text
-
-                    table_metadata[table_dbid][fid]['composite_field_parent_fid'] = parent_fid
-                    table_metadata[table_dbid][fid]['composite_field_child_fids'] = child_fids
-
-                    table_metadata[table_dbid][fid]['mode'] = field_xml.get('mode')
-
-                    table_metadata[table_dbid][fid]['formula'] = None
-                    if field_xml.find('formula') is not None:
-                        table_metadata[table_dbid][fid]['formula'] = field_xml.find('formula').text
-
-                    table_metadata[table_dbid][fid]['choices'] = None
-                    if field_xml.find('choices') is not None:
-                        table_metadata[table_dbid][fid]['choices'] = ""
-                        for choice in field_xml.findall('./choices/choice'):
-                            table_metadata[table_dbid][fid]['choices'] += "\n" + choice.text \
-                                                    if len(table_metadata[table_dbid][fid]['choices']) > 0 \
-                                                    else choice.text
-
-                    table_metadata[table_dbid][fid]['lookup_target_fid'] = None
-                    table_metadata[table_dbid][fid]['lookup_source_fid'] = None
-                    if table_metadata[table_dbid][fid]['mode'] == 'lookup':
-                        if field_xml.find('lutfid') is not None:
-                            table_metadata[table_dbid][fid]['lookup_target_fid'] = field_xml.find('lutfid').text
-                        if field_xml.find('lusfid') is not None:
-                            table_metadata[table_dbid][fid]['lookup_source_fid'] = field_xml.find('lusfid').text
-
-                    table_metadata[table_dbid][fid]['dblink_target_dbid'] = None
-                    table_metadata[table_dbid][fid]['dblink_target_fid'] = None
-                    table_metadata[table_dbid][fid]['dblink_source_fid'] = None
-                    if table_metadata[table_dbid][fid]['mode'] == 'virtual' and \
-                        table_metadata[table_dbid][fid]['field_type'] == 'dblink':
-                        if field_xml.find('target_dbid') is not None:
-                            table_metadata[table_dbid][fid]['dblink_target_dbid'] = field_xml.find('target_dbid').text
-                        if field_xml.find('target_fid') is not None:
-                            table_metadata[table_dbid][fid]['dblink_target_fid'] = field_xml.find('target_fid').text
-                        if field_xml.find('source_fid') is not None:
-                            table_metadata[table_dbid][fid]['dblink_source_fid'] = field_xml.find('source_fid').text
-                    table_metadata[table_dbid][fid]['fkey_table_app_dbid'] = None
-                    table_metadata[table_dbid][fid]['fkey_table_alias'] = None
-                    if field_xml.find('mastag') is not None:
-                        fkey_ref = field_xml.find('mastag').text.split('.')
-                        if len(fkey_ref) == 2:
-                            table_metadata[table_dbid][fid]['fkey_table_app_dbid'] = fkey_ref[0]
-                            table_metadata[table_dbid][fid]['fkey_table_alias'] = fkey_ref[1].lower()
-                        else:
-                            table_metadata[table_dbid][fid]['fkey_table_app_dbid'] = None
-                            table_metadata[table_dbid][fid]['fkey_table_alias'] = fkey_ref[0].lower()
-
-                    table_metadata[table_dbid][fid]['field_help'] = field_xml.find('fieldhelp').text
-
-                    # For each unique data id corresponding to a table,
-                    # build a list of all relevant fields
-                    if unique_data_id is not None and \
-                        (not default_display_only or \
-                         table_metadata[table_dbid][fid]['appears_by_default'] == '1'):
-                        self._fields[unique_data_id].append(field_name)
-
-                    field_count += 1
-
-                field_line_end = field_count + 1
-
-                app_metadata[table_dbid] = OrderedDict([
-					  ('table_name',                table_name),
-                      ('table_dbid',                table_dbid),
-                      ('table_alias',               app_table_metadata.get('name')),
-                      ('key_fid',                   table_metadata_xml_orig.find('key_fid').text),
-                      ('default_sort_fid',          table_metadata_xml_orig.find('def_sort_fid').text),
-                      ('default_sort_order',        table_metadata_xml_orig.find('def_sort_order').text),
-                      ('single_record_name',        table_metadata_xml_orig.find('single_record_name').text),
-                      ('plural_record_name',        table_metadata_xml_orig.find('plural_record_name').text),
-                      ('field_metadata_line_start', field_line_start),
-                      ('field_metadata_line_end',   field_line_end)
-                    ])
-
-                if unique_data_id is not None and unique_data_id in self._fields:
-                    # While not strictly a field, Quick Base always includes final 'update_id':
-                    self._fields[unique_data_id].append('update_id')
-                    # Set the query parameter string (including the sort field parameter):
-                    if not default_display_only:
-                        self._params[unique_data_id] = DhcdApiConn.PARAMS_DATA_ALL_FIELDS
-                    else:
-                        self._params[unique_data_id] = DhcdApiConn.PARAMS_DATA_DEFAULT_FIELDS
-                    self._params[unique_data_id]['slist'] = app_metadata[table_dbid]['default_sort_fid']
+                        self._params[unique_data_id]['slist'] = app_metadata[table_dbid]['default_sort_fid']
 
         all_tables_field_metadata = [ list(field_metadata_row.values()) \
                                         for all_field_metadata in table_metadata.values() \
@@ -318,18 +323,13 @@ class DhcdApiConn(ProjectBaseApiConn):
                 data_xml_records = data_xml_root.findall('record')
                 data_json = xml_to_json.data(data_xml_root)
 
-                if output_type == 'stdout':
-                    print(json.dumps(data_json, indent=4))
+                results = [ DhcdResult({e.tag: e.text for e in list(r)}, self._fields[u]).data for r in data_xml_records ]
 
-                elif output_type == 'csv':
-
-                    results = [ DhcdResult({e.tag: e.text for e in list(r)}, self._fields[u]).data for r in data_xml_records ]
-
-                    self.result_to_csv(self._fields[u], results, self.output_paths[u])
-                    
-                    #Convert to format expected by database
-                    if u == 'dhcd_dfd_properties':
-                        self.create_project_subsidy_csv('dhcd_dfd_properties', PROJECT_FIELDS_MAP, SUBSIDY_FIELDS_MAP, db)
+                self.result_to_csv(self._fields[u], results, self.output_paths[u])
+                
+                #Convert to format expected by database
+                if u == 'dhcd_dfd_properties':
+                    self.create_project_subsidy_csv('dhcd_dfd_properties', PROJECT_FIELDS_MAP, SUBSIDY_FIELDS_MAP, db)
 
 
 

--- a/python/housinginsights/sources/models/dhcd.py
+++ b/python/housinginsights/sources/models/dhcd.py
@@ -6,30 +6,33 @@ Model for DHCD DFD api
 APP_ID = 'bit4kvfmq'
 
 
+# TODO commented out mappings are b/c we are currently not using the 
+# data from these other tables. When we want to add additional 
+# data from these fields, we should uncomment them. 
 TABLE_ID_MAPPING = {
         'Projects'               : 'bit4krbdh',
         'Properties'             : 'bi4xqgzv4',
-        'Units'                  : 'bi5rjybzu',
-        'Loans'                  : 'bje8tw7zv',
-        'Modifications'          : 'bmdugdvkj',
-        'LIHTC Allocations'      : 'bje6i5q6n',
-        'Construction Activity'  : 'bje32df5p',
-        'Funding Sources'        : 'biwe8ny4f',
-        '8609s'                  : 'bmbugpa4q',
-        '8610s'                  : 'bk8mpqqqx',
-        'Source/Use'             : 'bk5cnab59',
-        'AMI Levels'             : 'bi5rib47y',
-        'Fiscal Years'           : 'bk8mkqy47',
-        'Organizations'          : 'bmhgudsjn',
-        'Teams'                  : 'bks6xc8h7',
-        'Project Managers'       : 'bknhzjtqb',
-        'Funding Increases'      : 'bmmnf2mzm',
-        'LIHTC Fees'             : 'bmsjssxp6',
-        'LIHTC - BINs'           : 'bms24sdeg',
-        'Council Packages'       : 'bmr6b6ipk',
-        'Policies and Procedures': 'bma2g4g7a',
-        'DHCD Documents'         : 'bknktet3x',
-        'Images/Icons'           : 'biw84iuzj'
+        #'Units'                  : 'bi5rjybzu',
+        #'Loans'                  : 'bje8tw7zv',
+        #'Modifications'          : 'bmdugdvkj',
+        #'LIHTC Allocations'      : 'bje6i5q6n',
+        #'Construction Activity'  : 'bje32df5p',
+        #'Funding Sources'        : 'biwe8ny4f',
+        #'8609s'                  : 'bmbugpa4q',
+        #'8610s'                  : 'bk8mpqqqx',
+        #'Source/Use'             : 'bk5cnab59',
+        #'AMI Levels'             : 'bi5rib47y',
+        #'Fiscal Years'           : 'bk8mkqy47',
+        #'Organizations'          : 'bmhgudsjn',
+        #'Teams'                  : 'bks6xc8h7',
+        #'Project Managers'       : 'bknhzjtqb',
+        #'Funding Increases'      : 'bmmnf2mzm',
+        #'LIHTC Fees'             : 'bmsjssxp6',
+        #'LIHTC - BINs'           : 'bms24sdeg',
+        #'Council Packages'       : 'bmr6b6ipk',
+        #'Policies and Procedures': 'bma2g4g7a',
+        #'DHCD Documents'         : 'bknktet3x',
+        #'Images/Icons'           : 'biw84iuzj'
 }
 
 

--- a/python/housinginsights/tools/dbtools.py
+++ b/python/housinginsights/tools/dbtools.py
@@ -14,7 +14,6 @@ from subprocess import check_output
 import csv
 import json
 import os
-import logging
 import time
 #import docker
 
@@ -69,7 +68,7 @@ def get_database_engine(database_choice):
 
     except Exception as e:
         print(e)
-        logging.warning("Error - are you trying to use the wrong Docker connect string?")
+        print("Error - are you trying to use the wrong Docker connect string?")
         time.sleep(5)
         raise e
 


### PR DESCRIPTION
Fixes the issue that the "dhcd_dfd_projects" table, which contains loan information, was returning empty. This was due to an error returned from quickbase that the query was too large. Fixed by only requesting default fields for now, and made note for future users that all fields could be obtained by chunking the request.

Also started making progress towards the reporting / QA task for verifying we are properly matching records. Added a 'found_via' parameter to the _get_nlihc_id_from_db method, telling how the element was identified, as well as the list of all the mar_ids that it found using the addresses. Set up useless function that when finished can use these mar_ids to geocode the project so that it doesn't need to be done during hte cleaning step.

TODO:

- map the fields of the dhcd_project table to the subsidy table so that we can use the data
- finish the _geocode_if_needed function; this will mean it doesn't need to occur during cleaning. 
    - Modify append_addresses so that it returns the in-memory copy of what it writes to teh file
    - move _geocode_if_needed below append_addresses, and use the resulting mar_ids to geocode the project.