### PR TITLE
Adds active_subsidized_units & percent_units_subsidized to zone_facts.

### DIFF
--- a/python/housinginsights/ingestion/LoadData.py
+++ b/python/housinginsights/ingestion/LoadData.py
@@ -666,6 +666,11 @@ class LoadData(object):
             'acs_median_rent', 'acs_upper_rent_quartile'
         ]
 
+        # dict with key/list pairs for summing filtered column values
+        filtered_sum_args = {  # [method, table_name, filter_name]
+            'active_subsidized_units': ['sum','project','proj_units_assist_max']
+        }
+
         # dict with key/list pairs for calling summarize_observations method
         summarize_obs_field_args = {  # [method, table_name, filter_name]
             'crime_count': ['count', 'crime', 'all'],
@@ -684,7 +689,8 @@ class LoadData(object):
         }
 
         zone_types = ['census_tract', 'ward', 'neighborhood_cluster']
-
+        residential_units_by_zone_type = res_units_by_zone_type
+        print("res_units_imported" + str(res_units_by_zone_type['census_tract'])[0:50])
         query_results = list()
 
         # populate columns accordingly for each zone_specific type
@@ -700,6 +706,52 @@ class LoadData(object):
                 except Exception as e:
                     logger.error("Couldn't get census data for {}".format(field))
                     logger.error(e)
+
+            # get field value[s] as column sum[s] from [mar and] project table[s]
+            for field in filtered_sum_args:
+                #
+                # conditional branch below (commented out) for later 
+                # differentiation, when we decide to run 
+                # _get_residential_units from here as well
+                # 
+                # if  field == 'active_subsidized_units':
+                # 
+
+                try:
+
+                    with self.engine.connect() as conn:
+
+                        q = '''
+                            SELECT COALESCE({grouping},'Unknown')
+                                , sum(proj_units_assist_max) 
+                                AS active_subsidized_units
+                            FROM project
+                            where status = 'Active' OR status IS NULL
+                            GROUP BY {grouping}
+                            ORDER BY {grouping}
+                            '''.format(grouping=zone_type)
+                        rproxy  =   conn.execute(q)
+                        rrows    =   rproxy.fetchall()
+                        subs_units = dict()
+                        subs_units['items'] = {r[0]:r[1] for r in rrows
+                            if r[0] != None and r[0] != ''
+                            }
+                        subs_units['grouping'] = zone_type
+                        subs_units['data_id'] = 'active_subsidized_units'
+                        field_values[field]  = subs_units['items']
+
+                        denominator = res_units_by_zone_type[zone_type]
+                        subs_rate = self._items_divide(subs_units, denominator)
+                        subs_perc = self._scale(subs_rate, 100)  # per 100
+                        field_values['percent_units_subsidized'] =  subs_perc['items']
+
+                # TODO do better error handling - 
+                # for interim development purposes only
+                except Exception as e:
+                    return {'items': None
+                        , 'notes': "Calculation failed for subsidy rates: {}".format(e)
+                        , 'grouping': zone_type
+                        , 'data_id': 'active_subsidized_units'}
 
             # get field value from building permits and crime table
             for field in sorted(summarize_obs_field_args,reverse=True): 
@@ -1001,7 +1053,6 @@ class LoadData(object):
             additional_wheres += " AND OFFENSE IN ('ROBBERY','HOMICIDE','ASSAULT W/DANGEROUS WEAPON','SEX ABUSE')"
         elif filter_name == 'nonviolent':
             additional_wheres += " AND OFFENSE NOT IN ('ROBBERY','HOMICIDE','ASSAULT W/DANGEROUS WEAPON','SEX ABUSE')"
-
 
         # Fallback for an invalid filter
         else:

--- a/python/scripts/meta.json
+++ b/python/scripts/meta.json
@@ -4343,6 +4343,20 @@
         "source_name": "construction_permits_rate",
         "sql_name": "construction_permits_rate",
         "type": "decimal"
+      },
+      {
+        "display_name": "Units Actively Subsidized",
+        "display_text": "Total residential units in actively subsidized projects",
+        "source_name": "active_subsidized_units",
+        "sql_name": "active_subsidized_units",
+        "type": "integer"
+      },
+      {
+        "display_name": "Units Subsidized as Percentage",
+        "display_text": "Percentage of residential units actively subsidized",
+        "source_name": "percent_units_subsidized",
+        "sql_name": "percent_units_subsidized",
+        "type": "decimal"
       }
     ]
   },


### PR DESCRIPTION
This revision gets the job done. Eventually, when we call _get_residential_units from within _populate_zone_facts_table, then the one-time query used here to filter and sum the column values proj_units_assist_max can ultimately be generalized and made into its own separate method. Then we also can trim back the argument res_units_by_zone presently passed to subsequent methods. For now, however, this one-time wrangling produces the results we want. 

That said, some data integrity problems also are brought to light. For example, in neighborhood cluster 38, 104% of the residential units are counted as actively "subsidized." Something clearly isn't being counted right, and we need to find out why not. More dramatically, in census tract 11001006804, 106 out of, yes, 13, units are counted as subsidized. So, some sleuthing is needed to see if residential units (from the mar table) are being under-counted or subsidized units (from the project table) are being over-counted..