### PR TITLE
540 578 slider fixes plus clear selected project fixes

### DIFF
--- a/docs/tool/js/core/router.js
+++ b/docs/tool/js/core/router.js
@@ -43,10 +43,11 @@ var router = {
     },
     pushFilter: function(msg, data){
         /*console.log(msg,data);*/
-        if (data.length === 0 || !data || ( msg === 'subNav.right' && data === 'charts') ) {
-            delete router.stateObj[msg];
-        } else if ( msg.split('.')[0] === 'previewBuilding' ) {
+        if ( msg.split('.')[0] === 'previewBuilding' ) {
+            //TODO Need to filter if data = null 
             router.stateObj['previewBuilding'] = data[0];
+        } else if (data.length === 0 || !data || ( msg === 'subNav.right' && data === 'charts') ) {
+            delete router.stateObj[msg];
         } else {
             router.stateObj[msg] = data;
         }

--- a/docs/tool/js/views/filter-view.js
+++ b/docs/tool/js/views/filter-view.js
@@ -504,7 +504,7 @@ var filterView = {
 
         this.isTouched = function(){
             var returnVals = ths.textBoxes.returnValues();
-            return returnVals.min.min != this.minDatum || returnVals.max.max != this.maxDatum || this.nullsShown === false;
+            return returnVals.min.min != this.minDatum || returnVals.max.max != this.maxDatum || ths.toggle.element.checked === false;
         };
 
         this.set = function(min,max,nullValue){
@@ -655,7 +655,7 @@ var filterView = {
 
         slider = document.getElementById(c.source);
         noUiSlider.create(slider, {
-            start: [minDatum, maxDatum],
+            start: [minDatum.getFullYear(), maxDatum.getFullYear()],
             connect: true,
             tooltips: [ false, false ],
             range: {
@@ -841,12 +841,11 @@ var filterView = {
         }
 
         this.isTouched = function(){
-            console.log(this);
             var dateValues = getValuesAsDates();
             if ( document.getElementById('filter-' + this.component.source).className.indexOf('invalid') !== -1 ) {
                 return true;
             }
-            return dateValues.min.valueOf() !== minDatum.valueOf() || dateValues.max.valueOf() !== maxDatum.valueOf() || this.nullsShown === false;
+            return dateValues.min.valueOf() !== minDatum.valueOf() || dateValues.max.valueOf() !== maxDatum.valueOf() || ths.toggle.element.checked === false;
         }
 
         this.checkAgainstOriginalValues = function(min,max,showNulls){

--- a/docs/tool/js/views/map-view.js
+++ b/docs/tool/js/views/map-view.js
@@ -1177,7 +1177,7 @@ frontmatter: isneeded
         clearSelectedProjectIfDoesntMatch: function() {
           var currentState = getState();
           if ( currentState.previewBuilding != null ){
-            var currentSelectedProject = getState().previewBuilding[0];
+            var currentSelectedProject = getState().previewBuilding[0][0];
             var filteredData = currentState.filteredData;
             var stillInGroup = false;
             if ( currentSelectedProject != null ){
@@ -1456,12 +1456,12 @@ frontmatter: isneeded
             
         },
         highlightPreviewBuilding(msg, data) {
-            var projectData = data[0];
             if ( getState().previewBuilding[1] ){ // if there's a previous previewBuilding state, clear the highlight
                 mapView.map.setFilter('project-highlight-preview-' + getState().previewBuilding[1][0].properties.nlihc_id, ['==', 'nlihc_id', '']);
                 mapView.map.removeLayer('project-highlight-preview-' + getState().previewBuilding[1][0].properties.nlihc_id);
             }
-            if (projectData) {
+            if (data != null) {
+                var projectData = data[0];
                 mapView.map.addLayer({
                     'id': 'project-highlight-preview-' + projectData.properties.nlihc_id,
                     'type': 'circle',


### PR DESCRIPTION
Several minor bug fixes:
- REAC date slider now init's properly w/ left slider at extreme left
- Clear filters button now works when the only filtering is the unchecked null checkbox
- Several cleanups to the clearing of the previewBuilding (note this is incomplete, need to remove from URLS). 

@ostermanj I left a TODO in router.js at around line 47 - that is the spot that we need to remove the previewBuilding from the url if the data is null. I wasn't sure how to do that properly and it'd likely be faster for you to make the quick fix. Can you take a look?