### PR TITLE
524 add row skipping & 479 add "503" error handling

### DIFF
--- a/python/housinginsights/sources/mar.py
+++ b/python/housinginsights/sources/mar.py
@@ -1,5 +1,6 @@
 
 from pprint import pprint
+from time import sleep
 
 from housinginsights.sources.base import BaseApiConn
 from housinginsights.sources.models.mar import MarResult, FIELDS
@@ -16,11 +17,68 @@ class MarApiConn(BaseApiConn):
 
     BASEURL = 'http://citizenatlas.dc.gov/newwebservices/locationverifier.asmx'
 
-    def __init__(self,baseurl=None,proxies=None,database_choice=None, debug=False):
+    def __init__(self, baseurl=None, proxies=None,
+                 database_choice=None, debug=False):
         super().__init__(baseurl=MarApiConn.BASEURL)
+        self.error_counter = 0
+        self.SLEEP_BASE_INT = 0.05  # default value for sleep interval in secs
+        self.MAX_RETRY = 3  # controls max number retries until exception thrown
 
-    
-    def find_addr_string(self, address,output_type=None, output_file=None):
+    def _handle_status_code_error(self, status_code, retry_secs, lookup_method,
+                                  *args):
+        """
+        Helper function for error code handling - currently only used for 503
+        status error codes. Could be easily expanded for others if we run
+        into more.
+
+        If MAX_RETRY is exceeded, the error logged and an exception is thrown.
+
+        :param status_code: passed status code that was flagged in response
+        :param retry_secs: try to capture indicated recommended server wait
+        time in seconds
+        :param lookup_method: string representation of the method that was
+        called that lead to the response error code thrown
+        :param args: the necessary args needed to retry the method again
+        """
+        self.error_counter += 1
+        err = "{0} :An error occurred during request: status {1} - " \
+              "method called {2}"
+
+        # if exceed MAX_RETRY or not 503 code - log error and throw exception
+        if self.error_counter > self.MAX_RETRY or status_code != 503:
+            self.error_counter = 0  # reset counter
+            err.format('FAIL', status_code, lookup_method)
+            logger.exception(err)
+            raise Exception(err)
+        else:
+            err.format('TRYING AGAIN', status_code, lookup_method)
+            logger.exception(err)
+
+        # sleep for a moment
+        if retry_secs is None:
+            sleep(self.SLEEP_BASE_INT * self.error_counter)
+        else:
+            sleep(retry_secs)  # based on server provided period of time
+
+        # retry previously called method again
+        if lookup_method == 'find_location':
+            location, output_type, output_file = args
+            self.find_location(location, output_type, output_file)
+        elif lookup_method == 'reverse_geocode':
+            xcoord, ycoord, output_type, output_file = args
+            self.reverse_geocode(xcoord, ycoord, output_type, output_file)
+        elif lookup_method == 'find_addr_string':
+            address, output_type, output_file = args
+            self.find_addr_string(address, output_type, output_file)
+        elif lookup_method == 'reverse_lat_lng_geocode':
+            latitude, longitude, output_type, output_file = args
+            self.reverse_lat_lng_geocode(latitude, longitude, output_type,
+                                         output_file)
+        elif lookup_method == 'reverse_address_id':
+            aid, output_type, output_file = args
+            self.reverse_address_id(aid, output_type, output_file)
+
+    def find_addr_string(self, address, output_type=None, output_file=None):
         """
         Get information about an address by using a complete address string
 
@@ -43,9 +101,13 @@ class MarApiConn(BaseApiConn):
 
         result = self.get('/verifyDCAddressThrouString2', params=params)  
         if result.status_code != 200:
-            err = "An error occurred during request: status {0}"
-            raise Exception(err.format(result.status_code))
-       
+            self._handle_status_code_error(result.status_code,
+                                           result.headers['retry-after'],
+                                           'find_addr_string', address,
+                                           output_type, output_file)
+
+        # reset counter
+        self.error_counter = 0
         return result.json()
 
     def find_location(self, location, output_type=None,
@@ -76,15 +138,19 @@ class MarApiConn(BaseApiConn):
         }
         result = self.get('/findLocation2', params=params)
         if result.status_code != 200:
-            err = "An error occurred during request: status {0}"
-            logger.exception(err.format(result.status_code))
-            raise Exception(err.format(result.status_code))
+            self._handle_status_code_error(result.status_code,
+                                           result.headers['retry-after'],
+                                           'find_location', location,
+                                           output_type, output_file)
         if output_type == 'stdout':
             pprint(result.json())
         elif output_type == 'csv':
             data = result.json()['returnDataset']['Table1']
             results = [MarResult(address).data for address in data]
             self.result_to_csv(FIELDS, results, output_file)
+
+        # reset counter
+        self.error_counter = 0
         return result.json()
 
     def reverse_geocode(self, xcoord, ycoord, output_type=None,
@@ -116,14 +182,19 @@ class MarApiConn(BaseApiConn):
         }
         result = self.get('/reverseGeocoding2', params=params)
         if result.status_code != 200:
-            err = "An error occurred during request: status {0}"
-            raise Exception(err.format(result.status_code))
+            self._handle_status_code_error(result.status_code,
+                                           result.headers['retry-after'],
+                                           'reverse_geocode', xcoord, ycoord,
+                                           output_type, output_file)
         if output_type == 'stdout':
             pprint(result.json())
         elif output_type == 'csv':
             data = result.json()['Table1']
             results = [MarResult(address) for address in data]
             self.result_to_csv(FIELDS, results, output_file)
+
+        # reset counter
+        self.error_counter = 0
         return result.json()
 
     def get_condo_count(self, location, output_type=None,
@@ -219,14 +290,19 @@ class MarApiConn(BaseApiConn):
         }
         result = self.get('/reverseLatLngGeocoding2', params=params)
         if result.status_code != 200:
-            err = "An error occurred during request: status {0}"
-            raise Exception(err.format(result.status_code))
+            self._handle_status_code_error(result.status_code,
+                                           result.headers['retry-after'],
+                                           'reverse_lat_lng_geocode', latitude,
+                                           longitude, output_type, output_file)
         if output_type == 'stdout':
             pprint(result.json())
         elif output_type == 'csv':
             data = result.json()['Table1']
             results = [MarResult(address) for address in data]
             self.result_to_csv(FIELDS, results, output_file)
+
+        # reset counter
+        self.error_counter = 0
         return result.json()
 
     def reverse_address_id(self, aid, output_type=None, output_file=None):
@@ -253,12 +329,17 @@ class MarApiConn(BaseApiConn):
         }
         result = self.get('/findAID2', params=params)
         if result.status_code != 200:
-            err = "An error occurred during request: status {0}"
-            raise Exception(err.format(result.status_code))
+            self._handle_status_code_error(result.status_code,
+                                           result.headers['retry-after'],
+                                           'reverse_address_id', aid,
+                                           output_type, output_file)
         if output_type == 'stdout':
             pprint(result.json())
         elif output_type == 'csv':
             data = result.json()['Table1']
             results = [MarResult(address) for address in data]
             self.result_to_csv(FIELDS, results, output_file)
+
+        # reset counter
+        self.error_counter = 0
         return result.json()


### PR DESCRIPTION
## What's In This

- looks like #524 is all ready complete: added missing `self.debug` line
- #479: added a new method that sleeps for default secs or number seconds provided in headers.retry-after response value. If it still fails after `MAX_RETRY` number of times, logs the error and throws an exception.

## Note & Testing
Still needs adequate testing to confirm instances of 503 status codes are being handled correctly - I wasn't able to generate one.

To test, just run load_data on any data source that requires calls to mar api - project uids are good examples.

## TODO
Implement similar solution for #512 - still need to determine where best to initial sleep timer