### PR TITLE
583 - made sure mar id is returned as str type and not as integer

### DIFF
--- a/python/housinginsights/tools/misc.py
+++ b/python/housinginsights/tools/misc.py
@@ -5,6 +5,7 @@ from housinginsights.sources.mar import MarApiConn
 from housinginsights.tools.logger import HILogger
 logger = HILogger(name=__file__, logfile="sources.log")
 
+
 def quick_address_cleanup(addr):
      #Used to perform common string replacements in addresses. 
         #The key is original, value is what we want it to become
@@ -36,10 +37,10 @@ def quick_address_cleanup(addr):
 
 
 def check_mar_for_address(addr, conn):
-        '''
+        """
         Looks for a matching address in the MAR
         Currently just uses a 
-        '''
+        """
 
         quick_address_cleanup(addr)
 
@@ -64,17 +65,18 @@ def check_mar_for_address(addr, conn):
         logger.info("  checking mar API")
         mar_api = MarApiConn()
         result = mar_api.find_addr_string(address=addr)
-        if (result['returnDataset'] == None or 
-            result['returnDataset'] == {} or
-            result['sourceOperation'] == 'DC Intersection'):
+        if (result['returnDataset'] is None or
+           result['returnDataset'] == {} or
+           result['sourceOperation'] == 'DC Intersection'):
 
-            #Means we didn't find a proper match
+            # means we didn't find a proper match
             result = None
 
+        # make sure to return address id as string and not default integer
         if result:
-            return result['returnDataset']['Table1'][0]['ADDRESS_ID']
+            return str(result['returnDataset']['Table1'][0]['ADDRESS_ID'])
 
-        #If no match found:
+        # if no match found:
         return None
 
 


### PR DESCRIPTION
## What's In This
In misc.py check_mar_for_address() we were return the address id result from mar api call as integer and using that for dedupe process for *_addre.csv. This was primarily occurring for dhcd raw data since it isn't processed with any address id metadata. Simply cast it as str type before returning the result.

## Test
Run get_api_data on dhcd unique data id and verify that all mar ids are string. Example is 1354 Euclid St.

## TODO
Since we're already calling mar api to get mar id for missing projects, we should go ahead and store that value in the output.csv (_project.csv & _addre.csv) instead of making another api call when we do geocode clean up in the cleaner code. I'll create a ticket to expand on this further.