### PR TITLE
New Website Copy in Preparation for Launch

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -33,8 +33,7 @@
 				<h1>Housing Insights</h1>
 				<h2>{{ site.tagline }}</h2>
 				<p>
-					<button type="button" data-toggle="modal" data-target="#modal_email" class="btn btn-primary btn-lg get-updates">Get updates</button>
-					<a href="resources" class="btn btn-primary btn-lg help-build">Help us build it</a>
+					<a href="tool" class="btn btn-primary btn-lg help-build">Explore the tool!</a>
 				</p>
 			</div>
 		</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,25 +11,12 @@ title: CTDC Home
 </div><!--this comment fixes inline-block space issue
 --><div class="col-xs-10 vcenter">
 <h1>The Housing Problem</h1>
-<p>Most affordable housing is owned privately, with government programs providing subsidies that allow them to rent to low-income residents at rates they can afford. Since the buildings are owned privately, owners can also stop participating in these programs - reducing the availability of housing for those who need it.</p>
+<p>Those fighting to preserve affordable housing face constant challenges and difficult decisions. While different groups generally agree on the list of factors to consider in preservation efforts, groups vary in how they prioritize these factors. Having access to common data lets us have a shared starting point for a more productive conversation. Data, moreover, provides context to decisions, helps prioritize limited funds and energy, and ensures affordable housing efforts are proactive rather than reactive.</p>
 
-<p>Affordable housing advocates and the DC government put time and money into <strong>preserving</strong> these buildings - keeping them participating - through refinancing, tenant organizing, and incentives. But they have limited resources, and need to know where their energy is best spent.</p>
+
 </div>
 </div>
 
-<hr>
-
-<div class="row margin-bottom">
-<div class="col-xs-2 vcenter">
-  {% include svg/binary-inspect.svg %}
-</div><!--this comment fixes inline-block space issue
---><div class="col-xs-10 vcenter">
-<h1>The Data Problem</h1>
-<p>Even getting a single list of all the affordable buildings in DC is a challenge. The <a href="http://www.neighborhoodinfodc.org/dcpreservationcatalog/">DC Preservation Catalog</a> provided a big step forward in solving this problem, collecting multiple data sources into a unified list of affordable buildings in DC. But to be more useful to partners it needs to be easier to access, browse and utilize.</p>
-
-<p>But there's a bigger challenge. Information about the neighborhoods surrounding the buildings is also important - a building that is close to public transit may be more important to preserve for example, or a building in a rapidly gentrifying neighborhood may be much more likely to be sold or converted.</p>
-</div>
-</div>
 
 <hr>
 
@@ -39,9 +26,16 @@ title: CTDC Home
 </div><!--this comment fixes inline-block space issue
 --><div class="col-xs-10 vcenter">
 <h1>Our Solution</h1>
-<p>The purpose of this project is to put better information in the hands of the decision makers and advocates for affordable housing. The Housing Insights website will make it easy to browse a list of all subsidized affordable housing in DC regardless of what subsidy program they are part of. And, it will connect to relevant outside data such as public transit, zoning, and neighborhood characteristics to make it easy to consider all the relevant factors when prioritizing and coordinating work.</p>
-
-<p>Together we can make this process easier, bringing open data sources to affordable housing decision makers.</p>
+<p> Housing Insights builds on the great work of the <a href="https://www.neighborhoodinfodc.org/dcpreservationcatalog/" target="_blank"> Preservation Catalog</a> to bring context to the fingertips of the affordable housing community. Housing Insights assembles essential information on all subsidized affordable housing in DC and connects it to relevant outside data such as public transit,  property tax assessments and neighborhood characteristics to make it easy to consider all the relevant factors when prioritizing and coordinating work.</p>
+<br>
+<p>Decision makers and advocates for affordable housing use Housing Insights to:</p>
+<ul>
+	<li>Identify projects that are at-risk or difficult to replace</li>
+	<li>Understand trends in neighborhood demographics</li>
+	<li>Access complete information on individual projects needed for action and intervention</li>
+</ul>
+<br>
+<p>Whether you are involved in the efforts to preserve affordable housing in DC or simply are an interested member of the public, we welcome you do Housing Insights and invite you to <a href="{{site.baseurl}}/tool">explore the tool!</a></p>
 </div>
 </div>
 
@@ -53,9 +47,8 @@ title: CTDC Home
 <div class="well get-involved">
 <h2>Affordable Housing Professionals</h2>
 <p class="lead text-info">Are you someone who works in DC Government, at a non-profit, or with affordable housing developments?</p>
-<p> We want to make this tool useful for you. <a href="{{site.baseurl}}/resources/contact">Contact</a> the project staff if you're interested in being a beta tester or be interviewed about what would make this tool most useful to you. Our monthly newsletter will also document project progress.</p>
+<p> We want to continue to improve this tool and need your input! <a href="{{site.baseurl}}/resources/contact">Contact</a> the project staff if you're interested in providing feedback on what would make this tool most useful to you. </p>
 
-<button type="button" class="btn btn-primary get-updates" data-toggle="modal" data-target="#modal_email">Get updates</button>
 </div>
 </div>
 
@@ -63,7 +56,7 @@ title: CTDC Home
 <div class="well get-involved">
 <h2>Coders and Developers</h2>
 <p class="lead text-info">Are you a coder, developer, or data enthusiast?</p>
-<p>Beginner or professional, do you want to give back to the community and help us build this tool? <a href="http://codefordc.org/">Code for DC</a> volunteers are doing the work to make this tool awesome. We're building a dynamic Javascript front-end, crunching our data with Python, and we can use your help no matter what your background or experience.</p>
+<p>Beginner or professional, do you want to give back to the community and help us continue to refine this tool? <a href="http://codefordc.org/">Code for DC</a> volunteers are doing the work to make this tool awesome. The tool uses a dynamic Javascript front-end, crunches our data with Python, and we can use your help no matter what your background or experience.</p>
 
 <a href="{{site.baseurl}}/resources" class="btn btn-primary help-build">Help us build it</a>
 </div>


### PR DESCRIPTION
Changed the website copy of the home page of housinginsights.org in preparation of launch. Changed the buttons in the _layouts/home.html to a single call-to-action to explore the tool. Removed the 'get updates' button in the 'Get involved: Affordable Housing Professionals